### PR TITLE
Use cover image names without paths or URL

### DIFF
--- a/2015-01-21-playlist-top-musique-2014.md
+++ b/2015-01-21-playlist-top-musique-2014.md
@@ -4,7 +4,7 @@ title: "La Playlist du Top Musique 2014"
 authors:
   - Dirty Henry
 tags: musique top
-cover: /assets/images/top-musique-2014.png
+cover: top-musique-2014.png
 cover_alt: Le podium, celui des champions
 description: >
   Dead Rooster donne ses médailles à l'occasion d'un comeback complètement 2.0 !

--- a/2015-02-26-neutral-milk-hotel.md
+++ b/2015-02-26-neutral-milk-hotel.md
@@ -4,7 +4,7 @@ title: "Neutral Milk Hotel, une Introduction"
 authors:
   - Dirty Henry
 tags: musique neutral-milk-hotel concert trianon jeff-mangum
-cover: /assets/images/neutral-milk-hotel-introduction.png
+cover: neutral-milk-hotel-introduction.png
 cover_alt: Pochette de In The Aeroplane Over The Sea, meilleur album 90s ?
 description: >
   Le meilleur concert de 2014 pour certains, le meilleur album des 90s pour

--- a/2015-03-19-education-musimentale.md
+++ b/2015-03-19-education-musimentale.md
@@ -4,7 +4,7 @@ title: "L'Éducation Musimentale"
 authors:
   - Joe Gantdelaine
 tags: musique
-cover: /assets/images/education-musimentale.png
+cover: education-musimentale.png
 cover_alt: Dans Almost Famous, Lester Bangs fait le bilan
 description: >
   Joe Gantdelaine vous présente sa famille musicale. Il en est fier souvent et

--- a/2015-05-09-laurent-chalumeau.md
+++ b/2015-05-09-laurent-chalumeau.md
@@ -7,7 +7,7 @@ tags:
   - laurent chalumeau
   - livres
   - michel sardou
-cover: http://s3-eu-west-1.amazonaws.com/org.deadrooster.blog/sardou-chalumeau.jpg
+cover: sardou-chalumeau.jpg
 description: >
   Quelles conclusions tirer de la lecture de Kif, de Laurent Chalumeau, sur
   notre relation à Michel Sardou ? Dead Rooster a mené l'enquête, bancale et

--- a/2015-07-20-les-guns.md
+++ b/2015-07-20-les-guns.md
@@ -5,7 +5,7 @@ authors:
   - Joe Gantdelaine
 tags:
   - encyclopédie approximative
-cover: https://s3-eu-west-1.amazonaws.com/org.deadrooster.blog/gunsnroses.jpg
+cover: gunsnroses.jpg
 cover_alt: Axl sur la différence entre le bon et le mauvais hardeuh rock
 description: >
   Il voulait rester femme, qu'importe le lieu, Manhattan ou Kaboul… Voici

--- a/2015-11-05-yo-la-tengo.md
+++ b/2015-11-05-yo-la-tengo.md
@@ -3,7 +3,7 @@ layout: post
 title: "Yo La Retengo"
 authors:
   - Joe Gantdelaine
-cover: https://s3-eu-west-1.amazonaws.com/org.deadrooster.blog/yolatengo.jpg
+cover: yolatengo.jpg
 cover_alt: Petit déjeuner pénard
 description: >
   Récit du concert depuis un fauteuil ultra confortable

--- a/2015-12-18-kurt-vile.md
+++ b/2015-12-18-kurt-vile.md
@@ -3,7 +3,7 @@ layout: post
 title: "Vile, Lumière d’Automne"
 authors:
   - Joe Gantdelaine
-cover: https://s3-eu-west-1.amazonaws.com/org.deadrooster.blog/kurt-vile.jpg
+cover: kurt-vile.jpg
 cover_alt: Sur la D922, Kurt Vile, ça passe trop bien !
 description: >
   Sur la route, tu peux lire Kerouac ou écouter Gérald. On The Road Again, tu

--- a/2016-04-27-bruce-springsteen.md
+++ b/2016-04-27-bruce-springsteen.md
@@ -5,7 +5,7 @@ authors:
   - Joe Gantdelaine
 tags:
   - encyclopédie approximative
-cover: https://s3-eu-west-1.amazonaws.com/org.deadrooster.blog/bruce.jpg
+cover: bruce.jpg
 cover_alt: Brousse lit
 description: >
   Il aura fallu du temps pour ce nouvel article de l'Encyclopédie Approximative

--- a/2016-09-06-clash.md
+++ b/2016-09-06-clash.md
@@ -5,7 +5,7 @@ authors:
   - Joe Gantdelaine
 tags:
   - encyclopédie approximative
-cover: https://s3-eu-west-1.amazonaws.com/org.deadrooster.blog/johnny-clash.jpg
+cover: johnny-clash.jpg
 description: >
   L’encyclopédie approximative est de retour, et ça clashe !
 ---

--- a/2017-01-10-compile-automne-2016.md
+++ b/2017-01-10-compile-automne-2016.md
@@ -6,7 +6,7 @@ authors:
   - Joe Gantdelaine
 tags:
   - compile
-cover: https://s3-eu-west-1.amazonaws.com/org.deadrooster.blog/un-automne-2016.jpg
+cover: automne-2016.jpg
 description: >
   Parce que les playlists c'est bien mais que les compiles c'est peut-être
   mieux. Parce que les Inrocks ne font plus le boulot correctement. Parce que

--- a/2017-01-17-compile-automne-2016-face-B.md
+++ b/2017-01-17-compile-automne-2016-face-B.md
@@ -5,7 +5,7 @@ authors:
   - Joe Gantdelaine
 tags:
   - compile
-cover: https://s3-eu-west-1.amazonaws.com/org.deadrooster.blog/un-automne-2016-B.jpg
+cover: automne-2016-b.jpg
 description: >
   Parce que 2 faces valent mieux qu'une. Dead Rooster présente... Un Automne
   2016, la face B.

--- a/2017-01-24-deep-purple.md
+++ b/2017-01-24-deep-purple.md
@@ -5,7 +5,7 @@ authors:
   - Joe Gantdelaine
 tags:
   - encyclopédie approximative
-cover: https://s3-eu-west-1.amazonaws.com/org.deadrooster.blog/deep-purple-smoke-water.jpg
+cover: deep-purple-smoke-water.jpg
 description: >
   Pouin-pouin-pouin Pouin-pouin'pouin-pouin Pouin-pouin-pouin Pouin-pouiiiiin
 ---

--- a/2017-04-03-compile-hiver-2017.md
+++ b/2017-04-03-compile-hiver-2017.md
@@ -5,7 +5,7 @@ authors:
   - Joe Gantdelaine
 tags:
   - compile
-cover: https://s3-eu-west-1.amazonaws.com/org.deadrooster.blog/Un-Hiver-2017.png
+cover: hiver-2017.png
 description: >
   Parce que les playlists c'est bien mais que les compiles c'est peut-être
   mieux. Parce que les Inrocks ne font plus le boulot correctement. Parce que

--- a/2017-07-30-compile-hiver-2017-face-B.md
+++ b/2017-07-30-compile-hiver-2017-face-B.md
@@ -5,7 +5,7 @@ authors:
   - Dirty Henry
 tags:
   - compile
-cover: https://s3-eu-west-1.amazonaws.com/org.deadrooster.blog/Un-Hiver-2017-face-B.png
+cover: hiver-2017-b.png
 description: >
   Parce que 2 faces valent mieux qu'une. Dead Rooster présente... Un Hiver 2017,
   la face B.

--- a/2017-09-27-compile-printemps-2017.md
+++ b/2017-09-27-compile-printemps-2017.md
@@ -5,7 +5,7 @@ authors:
   - Dirty Henry
 tags:
   - compile
-cover: https://s3-eu-west-1.amazonaws.com/org.deadrooster.blog/Un+Printemps+2017.jpg
+cover: printemps-2017.jpg
 description: >
   Ou Joe Dassin rend hommage à Hugo, et Marcel Proust s'en prend plein la
   gueule. Dead Rooster présente... Un Printemps 2017.

--- a/2017-10-10-compile-printemps-2017-face-B.md
+++ b/2017-10-10-compile-printemps-2017-face-B.md
@@ -5,7 +5,7 @@ authors:
   - Joe Gantdelaine
 tags:
   - compile
-cover: https://s3-eu-west-1.amazonaws.com/org.deadrooster.blog/Un+Printemps+2017-face+B.jpg
+cover: printemps-2017-b.jpg
 description: >
   Où on cause toons et tunes.
 ---

--- a/2017-11-03-compile-ete-2017.md
+++ b/2017-11-03-compile-ete-2017.md
@@ -5,7 +5,7 @@ authors:
   - Joe Gantdelaine
 tags:
   - compile
-cover: https://s3-eu-west-1.amazonaws.com/org.deadrooster.blog/Un+Été+2017.jpg
+cover: ete-2017.jpg
 description: >
   Automne-Hiver-Printemps-Eté, un an de compiles déjà !
 ---


### PR DESCRIPTION
Uniformization of cover names: it should just be the image name, no path (`/`), no scheme (`https://...`) and no special characters.