### PR TITLE
Fix markup

### DIFF
--- a/2015-01-21-playlist-top-musique-2014.md
+++ b/2015-01-21-playlist-top-musique-2014.md
@@ -55,7 +55,7 @@ temps][top-2011] ?
 
 OK, le disque date de 1998 mais ce fut la claque de 2014. Leur concert au
 Trianon fut de loin le meilleur depuis des lustres. J'en parle plus en détail
-[ici][neutral-milk-hotel-une-introduction].
+[ici][1].
 
 Pour la playlist, j'ai choisi les deux titres les plus immédiats de l'album _In
 The Aeroplane Over The Sea_ mais son écoute intégrale, comme celle de son
@@ -111,38 +111,9 @@ Interpol a sorti un album de très honorable facture, les autres aussi. Ce ne
 sont plus les artistes et groupes excitants de leur début, mais ils déçoivent
 peu. C'est tout à leur honneur.
 
-<div class="microdata" itemscope itemtype="http://schema.org/MusicPlaylist">
-  <span itemprop="name">Dead Rooster 2014 Playlist</span>
-  <meta itemprop="numTracks" content="6"/>
-  <div itemprop="track" itemscope itemtype="http://schema.org/MusicRecording">
-    1.<span itemprop="name">In The Aeroplane Over The Sea</span> -
-    <span itemprop="byArtist">Neutral Milk Hotel</span>
-  </div>
-  <div itemprop="track" itemscope itemtype="http://schema.org/MusicRecording">
-    2.<span itemprop="name">Weird Shapes</span> -
-    <span itemprop="byArtist">Surfer Blood</span>
-  </div>
-  <div itemprop="track" itemscope itemtype="http://schema.org/MusicRecording">
-    3.<span itemprop="name">The Fresh &amp; Onlys</span> -
-    <span itemprop="byArtist">Who Let The Devil</span>
-  </div>
-  <div itemprop="track" itemscope itemtype="http://schema.org/MusicRecording">
-    4.<span itemprop="name">Gandi Lake</span> -
-    <span itemprop="byArtist">Weather Vanes</span>
-  </div>
-  <div itemprop="track" itemscope itemtype="http://schema.org/MusicRecording">
-    5.<span itemprop="name">Bruce Springsteen</span> -
-    <span itemprop="byArtist">Down in the Hole</span>
-  </div>
-  <div itemprop="track" itemscope itemtype="http://schema.org/MusicRecording">
-    6.<span itemprop="name">Beck</span> -
-    <span itemprop="byArtist">Waking Light</span>
-  </div>
-</div>
-
 [top-2011]: http://www.deadrooster.org/Top-Musique-2011
 [magicrpm]: http://www.magicrpm.com
-[labelpop-podcast]: http://www.francemusique.fr/emission/label-pop
+[labelpop-podcast]: https://www.francemusique.fr/emission/label-pop
 [bravo-maestro-classe-americaine]: http://youtu.be/RQeLeRMRrTM
 [deezer-lineup-recommender]:
   https://www.facebook.com/deezerfr/app_1491856657769251
@@ -153,5 +124,4 @@ peu. C'est tout à leur honneur.
 [stone-et-charden-prix-des-alumettes]:
   https://www.youtube.com/watch?v=n8x1T_-XfMY
 
-[neutral-milk-hotel-une-introduction]:
-{% post_url 2015-02-26-neutral-milk-hotel %}
+[1]: {% post_url 2015-02-26-neutral-milk-hotel %}

--- a/2015-02-26-neutral-milk-hotel.md
+++ b/2015-02-26-neutral-milk-hotel.md
@@ -40,16 +40,15 @@ stabilise. Julian Koster (qui joue un peu de tout mais notamment du banjo et de
 la scie musicale), Scott Spillane (cuivres) et Jeremy Barnes (batterie) sont
 désormais des membres à part entière.
 
-![Jeff, Scott, Julian et Jeremy : le lineup de Neutral Milk Hotel](assets/images/neutral-milk-hotel-lineup-90s.jpg)
+{% asset neutral-milk-hotel-lineup-90s.jpg alt='Jeff, Scott, Julian et Jeremy : le lineup de Neutral Milk Hotel' %}
 
 En 1998, le second _In An Aeroplane Over The Sea_, avec Schneider à la
 production, est un chef-d'œuvre. À sa sortie, les critiques sont emballés et si
 les ventes restent confidentielles, leur niveau ne s'affaisse pas, jamais. Il
-finit même 6ème vinyle le plus vendu de l'année...
-[en 2008](http://www.rollingstone.com/music/news/radiohead-neutral-milk-hotel-help-vinyl-sales-almost-double-in-2008-20090108).
-Et finalement le groupe en vendra un bon paquet. Côté critique, Pitchfork le
-nomme 4ème meilleur album des 90s tandis que le plus méconnu Magnet le place à
-la 1ère place, devant Nirvana, Radiohead et les autres.
+finit même 6ème vinyle le plus vendu de l'année… [en 2008][5]. Et finalement le
+groupe en vendra un bon paquet. Côté critique, Pitchfork le nomme 4ème meilleur
+album des 90s tandis que le plus méconnu Magnet le place à la 1ère place, devant
+Nirvana, Radiohead et les autres.
 
 ## Que faire après le chef-d'œuvre ?
 
@@ -83,7 +82,7 @@ Ce n'était pas le premier concert de reformation que j'allais voir et même si
 certains furent très convaincants (Blur à Hyde Park, Pulp à Primavera), je
 savais aussi que le pari est parfois risqué (The La’s à Rock en Seine).
 
-![Jeff Mangum en 2014](assets/images/neutral-milk-hotel-jeff-mangum-2014.jpg)
+{% asset neutral-milk-hotel-jeff-mangum-2014.jpg alt='Jeff Mangum en 2014' %}
 
 Pourtant, les premiers titres ne laissent plus place au doute : le concert va
 être excellent. Jeff Mangum arrive seul, à droite de la scène pour attaquer
@@ -134,13 +133,6 @@ Pis, quand même une playlist pour finir :
 - je vous ai épargné un morceau de musique folklorique bulgare qui est le kiff
   actuel de Mangum
 
-<div class="microdata" itemprop="performer" itemscope="" itemtype="http://schema.org/MusicGroup">
-  <link itemprop="sameAs" href="http://fr.wikipedia.org/wiki/Neutral_Milk_Hotela" />
-  <div>
-    <span itemprop="name">Neutral Milk Hotel</span></a>
-  </div>
-</div>
-
 **EDIT (novembre 2016)** : pour vous mettre dans l'ambiance de Athens, Géorgie,
 en 1997, voici un petit live dans une maison.
 
@@ -152,3 +144,5 @@ en 1997, voici un petit live dans une maison.
   http://diffuser.fm/jeff-mangum-plays-intimate-show-tells-audience-theyll-never-hear-his-new-songs/
 [4]:
   http://pitchfork.com/news/57791-neutral-milk-hotel-announce-last-tour-for-the-forseeable-future/
+[5]:
+  https://www.rollingstone.com/music/music-news/radiohead-neutral-milk-hotel-help-vinyl-sales-almost-double-in-2008-252602/

--- a/2015-05-09-laurent-chalumeau.md
+++ b/2015-05-09-laurent-chalumeau.md
@@ -27,7 +27,7 @@ l'histoire d'une famille où les parents sont sourd-muets et la fille chanteuse.
 Ouais, OK, y'a François Damiens, Karin Viard et Eric Elmosnino qui jouent dedans
 ? Allez ! Pourquoi pas.
 
-![Avec le recul, je me dis que chanter, ça doit marcher mieux que la guitare](https://s3-eu-west-1.amazonaws.com/org.deadrooster.blog/famille_belier.jpg)
+{% asset famille_belier.jpg alt='Avec le recul, je me dis que chanter, ça doit marcher mieux que la guitare' %}
 
 Près de deux heures plus tard, quelques grosses ficelles qui n'auront malgré
 tout pas déplu commencent à nous faire chialer devant [un duo d'ados qui chante

--- a/2015-11-05-yo-la-tengo.md
+++ b/2015-11-05-yo-la-tengo.md
@@ -68,11 +68,13 @@ membres du groupe sont au moins aussi intelligents et cultivés que leur public.
 J'avoue que j'aurais du mal à extraire des grands moments de ce concert. Il n'y
 a pas eu de "tubes" au sens strict du terme et globalement, le concert formait
 un ensemble uniforme (peut-être trop ?). D'ailleurs, cette uniformité est
-peut-être la grande force de ce concert : si on regarde la
-[setlist](http://www.setlist.fm/setlist/yo-la-tengo/2015/la-cigale-paris-france-bf58142.html),
-une bonne moitié est constituée de reprises. Mais ce soir-là, on n'entendait que
-des chansons de Yo La Tengo !
+peut-être la grande force de ce concert : si on regarde la [setlist][1], une
+bonne moitié est constituée de reprises. Mais ce soir-là, on n'entendait que des
+chansons de Yo La Tengo !
 
 En fin de compte, on gardera avant tout le souvenir d'une excellente soirée, où
 l'on aura pu apprécier pendant deux heures un monde de douceur avec des
 camarades en New Balance. Moelleux !
+
+[1]:
+  http://www.setlist.fm/setlist/yo-la-tengo/2015/la-cigale-paris-france-bf58142.html

--- a/2017-01-17-compile-automne-2016-face-B.md
+++ b/2017-01-17-compile-automne-2016-face-B.md
@@ -105,5 +105,6 @@ oreilles vers [_Un Hiver 2017_][hiver-2017] !
 
 [chiant]: https://youtu.be/SbZL91_Kvi0
 
-[faceA]: {% post_url 2017-01-10-compile-automne-2016 %} [hiver-2017]:
-{% post_url 2017-04-03-compile-hiver-2017 %}
+[faceA]: {% post_url 2017-01-10-compile-automne-2016 %}
+
+[hiver-2017]: {% post_url 2017-04-03-compile-hiver-2017 %}


### PR DESCRIPTION
Prettier broke a certain number of things when we starting using it to format ~~Markdown~~ CommonMark, so this PR fixes some of that, and also replaces occurrences of `![alt](link)` by `{% asset file alt="alt" %}`.