### PR TITLE
fix: typo in YAML

### DIFF
--- a/2008-07-04-radiohead-arenes-nimes-in-rainbows.md
+++ b/2008-07-04-radiohead-arenes-nimes-in-rainbows.md
@@ -38,7 +38,7 @@ comments:
     date: "2008-07-08 23:14:00 +0200"
     title: Une tête de radio au pays des Jean-Mi
     content: Je confirme, j’y étais le 14. Je me disais aussi !
-- cover: radiohead.jpg
+cover: radiohead.jpg
 ---
 
 Dans le paysage rock actuel, il existe un certain type de groupes que le fan


### PR DESCRIPTION
Fixing the following error: 

```
Error: YAML Exception reading /home/travis/build/DeadRooster/deadrooster.org/_posts/2008-07-04-radiohead-arenes-nimes-in-rainbows.md: (<unknown>): did not find expected key while parsing a block mapping at line 2 column 1
```

as detected by CI at https://travis-ci.org/github/DeadRooster/deadrooster.org/builds/722010493