### PR TITLE
Fix deprecation warnings on post_url names

### DIFF
--- a/2006/2006-04-05-dirty-pretty-things-trabendo.md
+++ b/2006/2006-04-05-dirty-pretty-things-trabendo.md
@@ -31,4 +31,4 @@ standing to your right come on
 [1]:
   https://open.spotify.com/album/2prIc5Om2QPCGIjKVC5UQj?si=HqI-mPT6Sf-jlom_dIXEZQ
 
-[i1]: {% post_url 2006-01-21-ringos %}
+[i1]: {% post_url 2006/2006-01-21-ringos %}

--- a/2007/2007-04-02-valerie-leulliot-au-cafe-de-la-danse.md
+++ b/2007/2007-04-02-valerie-leulliot-au-cafe-de-la-danse.md
@@ -55,4 +55,4 @@ le pavé de la place de la Bastille.
 [2]: http://www.dailymotion.com/video/x8923a_falaise-sans-piles-session_music
 [3]: http://youtu.be/Gv4CX5XLdLU
 
-[i1]: :{% post_url 2007-03-30-fountains-of-wayne-traffic-and-weather %}
+[i1]: :{% post_url 2007/2007-03-30-fountains-of-wayne-traffic-and-weather %}

--- a/2007/2007-05-02-les-hymnes-inde-selon-le-nme.md
+++ b/2007/2007-05-02-les-hymnes-inde-selon-le-nme.md
@@ -73,4 +73,4 @@ penser que Vertigo est et demeurera le meilleur titre des Libertines ?!)
 49. The Rapture - _House Of Jealous Lovers_
 50. My Bloody Valentine - _You Made Me Realise_
 
-[i1]: {% post_url 2012-04-20-oasis-live-forever %}
+[i1]: {% post_url 2012/2012-04-20-oasis-live-forever %}

--- a/2008/2008-08-29-soleded-brothers-next.md
+++ b/2008/2008-08-29-soleded-brothers-next.md
@@ -63,4 +63,4 @@ http://creativecommons.org/licenses/by-nc-sa/2.0
 [7]: http://www.lightspeedchampion.com/bmachine/devwrites.php?id=246
 
 [1]:
-{% post_url 2006-06-07-les-soledad-brothers-sont-morts-vivent-les-bellrays %}
+{% post_url 2006/2006-06-07-les-soledad-brothers-sont-morts-vivent-les-bellrays %}

--- a/2008/2008-10-27-zoom-sur-le-zim.md
+++ b/2008/2008-10-27-zoom-sur-le-zim.md
@@ -47,4 +47,4 @@ Pour finir voici une liste sélective du monde de Dylan, à goûter sur le net :
 
 [2]: http://fr.wikipedia.org/wiki/Traveling_Wilburys
 
-[1]: {% post_url 2010-02-13-zoom-sur-le-zep %}
+[1]: {% post_url 2010/2010-02-13-zoom-sur-le-zep %}

--- a/2008/2008-11-25-gallagher-comme-a-la-guerre.md
+++ b/2008/2008-11-25-gallagher-comme-a-la-guerre.md
@@ -168,4 +168,4 @@ Bref, concernant le versant "Oasis en live", c'était mieux avant ! (L'Olympia d
 [7]:
   http://jiwa.fr/track/The-Lightning-Seeds-43804/Driving-Desire-98568/You-Showed-Me-346741.html
 
-[i1]: {% post_url 2012-04-20-oasis-live-forever %}
+[i1]: {% post_url 2012/2012-04-20-oasis-live-forever %}

--- a/2009/2009-01-20-top-musique-2008.md
+++ b/2009/2009-01-20-top-musique-2008.md
@@ -88,8 +88,8 @@ l'année, voire la décennie.
 - Photo MGMT : [©Oliver Peel](http://www.flickr.com/photos/oliverpeel/)
 
 [i1]:
-{% post_url 2008-06-19-scarlett-johansson-anywhere-i-lay-my-head-she-him-volume-one %}
+{% post_url 2008/2008-06-19-scarlett-johansson-anywhere-i-lay-my-head-she-him-volume-one %}
 
-[i2]: {% post_url 2008-07-29-fleet-foxes %}
+[i2]: {% post_url 2008/2008-07-29-fleet-foxes %}
 
-[i3]: {% post_url 2008-06-03-mgmt-bataclan %}
+[i3]: {% post_url 2008/2008-06-03-mgmt-bataclan %}

--- a/2009/2009-03-04-top-musique-2008-par-dead-rooster-canal-historique.md
+++ b/2009/2009-03-04-top-musique-2008-par-dead-rooster-canal-historique.md
@@ -190,6 +190,6 @@ Quelques liens utiles :
 [1]: http://www.allmusic.com
 [2]: https://song.link/i/1470532632
 
-[i1]: {% post_url 2008-07-08-the-notwist-devil-you-plus-me %}
+[i1]: {% post_url 2008/2008-07-08-the-notwist-devil-you-plus-me %}
 
-[i2]: {% post_url 2008-09-09-route-du-rock-2008 %}
+[i2]: {% post_url 2008/2008-09-09-route-du-rock-2008 %}

--- a/2009/2009-05-03-laurent-chalumeau-un-mec-sympa.md
+++ b/2009/2009-05-03-laurent-chalumeau-un-mec-sympa.md
@@ -61,4 +61,4 @@ Photo : [©scottnj](http://www.flickr.com/photos/scottod/)
 [2]: http://www.youtube.com/watch?v=tQZTa15sp0M
 [3]: http://www.youtube.com/watch?v=T4UyOmpmEsc
 
-[i1]: {% post_url 2015-05-09-laurent-chalumeau %}
+[i1]: {% post_url 2015/2015-05-09-laurent-chalumeau %}

--- a/2011/2011-05-05-yann-tiersen-dust-lane.md
+++ b/2011/2011-05-05-yann-tiersen-dust-lane.md
@@ -84,4 +84,4 @@ yeux.][4]
 [5]: https://deadrooster.org/top-musique-2010/
 [6]: https://deadrooster.org/qui-es-tu-nolwenn-leroy/
 
-[1]: {% post_url 2010-09-02-high-violet-haute-voltige %}
+[1]: {% post_url 2010/2010-09-02-high-violet-haute-voltige %}

--- a/2013/2013-03-29-electric-soft-parade-brother-you-must-walk-your-path-alone.md
+++ b/2013/2013-03-29-electric-soft-parade-brother-you-must-walk-your-path-alone.md
@@ -20,4 +20,4 @@ rajeunit pas.
 (via Carole)
 
 [1]:
-{% post_url 2007-05-05-electric-soft-parade-if-that-s-the-case-then-i-don-t-know %}
+{% post_url 2007/2007-05-05-electric-soft-parade-if-that-s-the-case-then-i-don-t-know %}

--- a/2013/2013-12-03-outside-llewyn-davis.md
+++ b/2013/2013-12-03-outside-llewyn-davis.md
@@ -97,4 +97,4 @@ l'auteur d'une anthologie.
 [2]: http://www.allocine.fr/article/dossiers/cinema/dossier-18591309/
 [4]: https://www.youtube.com/watch?v=978uQUK231M
 
-[3]: {% post_url 2013-11-12-inside-llewyn-davis %}
+[3]: {% post_url 2013/2013-11-12-inside-llewyn-davis %}

--- a/2014/2014-03-03-eurovision-2014.md
+++ b/2014/2014-03-03-eurovision-2014.md
@@ -28,4 +28,4 @@ Les _meaningless lyrics_ sont bien là, mais le reste ? Le monde va mal !
 [1]:
   http://www.rtl.fr/actualites/culture-loisirs/musique/article/eurovision-2014-le-groupe-twin-twin-representera-la-france-7770111522
 
-[2]: {% post_url 2007-07-04-neil-hannon-eurovision %}
+[2]: {% post_url 2007/2007-07-04-neil-hannon-eurovision %}

--- a/2014/2014-04-03-j-aim-ascis-1-2.md
+++ b/2014/2014-04-03-j-aim-ascis-1-2.md
@@ -78,4 +78,4 @@ foulée, Dinosaur (l'album), le nouveau venu dans ma discothèque, récoltait un
 [3]: https://www.youtube.com/watch?v=Dl5FclARrg0
 [4]: https://www.youtube.com/watch?v=pF_Fi7x93PY
 
-[5]: {% post_url 2014-04-30-j-aim-ascis-2-2 %}
+[5]: {% post_url 2014/2014-04-30-j-aim-ascis-2-2 %}

--- a/2014/2014-04-30-j-aim-ascis-2-2.md
+++ b/2014/2014-04-30-j-aim-ascis-2-2.md
@@ -79,4 +79,4 @@ avec sa guitare téléguidée][8] (notez l'épanadiplose).
 [7]:
   http://keepcompany.fr/chaussures-collabs/collabs-shaheen/shaheen-dinaosaur-jr.html
 
-[8]: {% post_url 2014-04-03-j-aim-ascis-1-2 %}
+[8]: {% post_url 2014/2014-04-03-j-aim-ascis-1-2 %}

--- a/2015/2015-01-21-playlist-top-musique-2014.md
+++ b/2015/2015-01-21-playlist-top-musique-2014.md
@@ -124,4 +124,4 @@ peu. C'est tout à leur honneur.
 [stone-et-charden-prix-des-alumettes]:
   https://www.youtube.com/watch?v=n8x1T_-XfMY
 
-[1]: {% post_url 2015-02-26-neutral-milk-hotel %}
+[1]: {% post_url 2015/2015-02-26-neutral-milk-hotel %}

--- a/2017/2017-01-10-compile-automne-2016.md
+++ b/2017/2017-01-10-compile-automne-2016.md
@@ -99,4 +99,4 @@ Par ici pour la [face B][faceb].
 [samedi-soir-2]: http://www.deadrooster.org/La-compile-du-samedi-soir-volume-2
 [cover]: https://twitter.com/christhebarker/status/815342375354662912
 
-[faceB]: {% post_url 2017-01-17-compile-automne-2016-face-B %}
+[faceB]: {% post_url 2017/2017-01-17-compile-automne-2016-face-B %}

--- a/2017/2017-01-17-compile-automne-2016-face-B.md
+++ b/2017/2017-01-17-compile-automne-2016-face-B.md
@@ -106,6 +106,6 @@ morceaux de la playlist hebdomadaire. 😀
 
 [chiant]: https://youtu.be/SbZL91_Kvi0
 
-[faceA]: {% post_url 2017-01-10-compile-automne-2016 %}
+[faceA]: {% post_url 2017/2017-01-10-compile-automne-2016 %}
 
-[hiver-2017]: {% post_url 2017-04-03-compile-hiver-2017 %}
+[hiver-2017]: {% post_url 2017/2017-04-03-compile-hiver-2017 %}

--- a/2020/2020-09-09-doves-cathedrals-of-the-mind.md
+++ b/2020/2020-09-09-doves-cathedrals-of-the-mind.md
@@ -31,4 +31,4 @@ a pas mal de temps.
 [2]: https://open.spotify.com/album/4HihJAJjF6hSVoh318zLu9
 [3]: https://dovesofficial.com
 
-[i1]: {% post_url 2009-10-18-500-nicolas-et-max %}
+[i1]: {% post_url 2009/2009-10-18-500-nicolas-et-max %}

--- a/2020/2020-09-14-bloc-party-two-more-years.md
+++ b/2020/2020-09-14-bloc-party-two-more-years.md
@@ -27,6 +27,6 @@ foulée aussi tiens. Les autres attendront.
 
 [1]: https://soundcloud.com/hooray-henrys/helicopter-bloc-party-cover
 
-[i1]: {% post_url 2020-05-01-phoenix %}
+[i1]: {% post_url 2020/2020-05-01-phoenix %}
 
-[i2]: {% post_url 2005-12-31-compile-automne-2005 %}
+[i2]: {% post_url 2005/2005-12-31-compile-automne-2005 %}

--- a/2020/2020-09-23-eurovision-song-contest-the-story-of-fire-saga.md
+++ b/2020/2020-09-23-eurovision-song-contest-the-story-of-fire-saga.md
@@ -72,10 +72,10 @@ relire ça dans 10 ans.
 [5]:
   https://www.theringer.com/movies/2020/7/15/21325097/making-of-wedding-crashers-football-scene
 
-[i1]: {% post_url 2007-07-04-neil-hannon-eurovision %}
+[i1]: {% post_url 2007/2007-07-04-neil-hannon-eurovision %}
 
-[i2]: {% post_url 2007-01-17-niveau-releve-pour-le-prochain-eurovision %}
+[i2]: {% post_url 2007/2007-01-17-niveau-releve-pour-le-prochain-eurovision %}
 
-[i3]: {% post_url 2014-03-03-eurovision-2014 %}
+[i3]: {% post_url 2014/2014-03-03-eurovision-2014 %}
 
-[i4]: {% post_url 2018-11-23-pixar-movie-challenge %}
+[i4]: {% post_url 2018/2018-11-23-pixar-movie-challenge %}

--- a/2020/2020-09-26-black-bones-destiny.md
+++ b/2020/2020-09-26-black-bones-destiny.md
@@ -14,8 +14,9 @@ Des anciens de Bewitched Hands, dont on a déjà chanté les louanges sur ce sit
 pour un [concert à emporter][i1] à revoir, et pour une [critique de disque][i2]
 où on signalait un talent indéniable mais à affiner. Chose faite ?
 
-[i1]: {% post_url 2011-10-07-the-bewitched-hands-hard-to-cry %}
+[i1]: {% post_url 2011/2011-10-07-the-bewitched-hands-hard-to-cry %}
 
-[i2]: {% post_url 2011-11-03-les-disques-d-octobre-2011 %}
+[i2]: {% post_url 2011/2011-11-03-les-disques-d-octobre-2011 %}
 
-[i3]: {% post_url 2020-09-23-eurovision-song-contest-the-story-of-fire-saga %}
+[i3]:
+{% post_url 2020/2020-09-23-eurovision-song-contest-the-story-of-fire-saga %}


### PR DESCRIPTION
Building Jekyll after [using directories for years](https://github.com/DeadRooster/articles/pull/62) outputs these warnings:

```
Deprecation: A call to '{% post_url 2017-01-10-compile-automne-2016 %}' did not match a post using the new matching method of checking name (path-date-slug) equality. Please make sure that you change this tag to match the post's name exactly.
       Deprecation: A call to '{% post_url 2017-04-03-compile-hiver-2017 %}' did not match a post using the new matching method of checking name (path-date-slug) equality. Please make sure that you change this tag to match the post's name exactly.
       Deprecation: A call to '{% post_url 2009-10-18-500-nicolas-et-max %}' did not match a post using the new matching method of checking name (path-date-slug) equality. Please make sure that you change this tag to match the post's name exactly.
```

This PR fixes that.