### PR TITLE
Fix legacy `->` SPIP links leftovers

### DIFF
--- a/2006/2006-06-01-interpol-turn-on-the-bright-lights.md
+++ b/2006/2006-06-01-interpol-turn-on-the-bright-lights.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Coldwave badante
+title: Interpol - Turn on the Bright Lights
 authors:
   - Dirty Henry
 wordpress_id: 316

--- a/2010/2010-06-03-velo-a-moteur-oui-mais.md
+++ b/2010/2010-06-03-velo-a-moteur-oui-mais.md
@@ -1,13 +1,6 @@
 ---
 layout: post
 title: Vélo à moteur ? Oui mais…
-description:
-  "[Un cycliste aurait récemment gagné des courses en dissimulant un moteur
-  électrique dans son
-  vélo->http://www.lequipe.fr/Cyclisme/breves2010/20100601_175537_cancellara-nie.html]
-  et ça fait scandale. Mais personne ne parle des rumeurs affirmant qu'Alain
-  Prost a été champion du monde de F1 sur une voiture à pédales. Le monde va mal
-  !"
 authors:
   - Dirty Henry
 wordpress_id: 621

--- a/2010/2010-07-16-admiral-radley-aime-la-california-meow.md
+++ b/2010/2010-07-16-admiral-radley-aime-la-california-meow.md
@@ -16,16 +16,17 @@ tags:
   - Single
 ---
 
-{_Admiral Radley_} est le nouveau groupe de Jason Lytle, ex-Grandaddy, qui vient
+**Admiral Radley** est le nouveau groupe de Jason Lytle, ex-Grandaddy, qui vient
 de sortir son premier album, _I Heart California_, dont est extrait le single
-karaoke ci-dessous.
+karaoke ci-dessous (edit : la vidéo originale ayant disparu, on l'a remplacée
+par un live sur KEXP, où les meow ont disparu).
 
-Malgré de beaux efforts, Admiral Radley a encore un train de retard sur [Nada
-Surf](http://www.youtube.com/watch?v=_Lh8uysjKwg] et sur
+Malgré de beaux efforts, Admiral Radley a encore un train de retard sur
+[Nada Surf](http://www.youtube.com/watch?v=_Lh8uysjKwg) et sur
 [Eric](http://www.youtube.com/watch?v=VgxFt_zqvqg) en terme d'imitation de
-chats. [Le titre peut être téléchargé ici
-!->http://stereogum.com/366082/admiral-radley-i-heart-california-stereogum-premiere/mp3s/)
+chats.
+[Le titre peut être téléchargé ici !](http://stereogum.com/366082/admiral-radley-i-heart-california-stereogum-premiere/mp3s/)
 
 Pas encore de date en France, mais bon, on s'tient au jus !
 
-<object id="flashObj" width="480" height="270" classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" codebase="http://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab#version=9,0,47,0"><param name="movie" value="http://c.brightcove.com/services/viewer/federated_f9/88099121001?isVid=1&isUI=1" /><param name="bgcolor" value="#FFFFFF" /><param name="flashVars" value="videoId=110081082001&playerID=88099121001&domain=embed&dynamicStreaming=true" /><param name="base" value="http://admin.brightcove.com" /><param name="seamlesstabbing" value="false" /><param name="allowFullScreen" value="true" /><param name="swLiveConnect" value="true" /><param name="allowScriptAccess" value="always" /><embed src="http://c.brightcove.com/services/viewer/federated_f9/88099121001?isVid=1&isUI=1" bgcolor="#FFFFFF" flashVars="videoId=110081082001&playerID=88099121001&&domain=embed&dynamicStreaming=true" base="http://admin.brightcove.com" name="flashObj" width="480" height="270" seamlesstabbing="false" type="application/x-shockwave-flash" allowFullScreen="true" allowScriptAccess="always" swLiveConnect="true" pluginspage="http://www.macromedia.com/shockwave/download/index.cgi?P1_Prod_Version=ShockwaveFlash"></embed></object>
+{% youtube wJWXGlaQUCw %}

--- a/2010/2010-07-18-the-notwist-s-gloomy-planets.md
+++ b/2010/2010-07-18-the-notwist-s-gloomy-planets.md
@@ -23,8 +23,9 @@ par un orchestre symphonique et qu'on habille le tout d'une chorégraphie
 lumineuse très classe ? Une vidéo qui donne des frissons.
 
 The Notwist est un groupe inégal mais parfois capable de coups de génies
-([on en parle ici](211]). Le titre _Gloomy Planets_ est l'un de ceux-ci. La
-vidéo est ci-dessous. Merci à [how to
-disappear->http://blog.howtodisappear.org/) de nous l'avoir fait remarquer.
+([on en parle ici](211)). Le titre _Gloomy Planets_ est l'un de ceux-ci. La
+vidéo est ci-dessous. Merci à
+[how to disappear](http://blog.howtodisappear.org/) de nous l'avoir fait
+remarquer.
 
 {% youtube x2qKfzIpoQg %}

--- a/2010/2010-07-24-la-nba-envahit-les-bacs.md
+++ b/2010/2010-07-24-la-nba-envahit-les-bacs.md
@@ -1,11 +1,6 @@
 ---
 layout: post
 title: La NBA envahit les bacs !
-description:
-  "[Rony Seikaly](http://en.wikipedia.org/wiki/Rony_Seikaly] est
-  [DJ->http://www.thetripwire.com/news/2010/07/23/rony-seikaly-will-now-be-making-some-music-news-thank-you)
-  ? Peut-être mais moi, j'attends toujours un concert de Šarūnas Marčiulionis !
-  Le monde va mal !"
 authors:
   - Dirty Henry
 wordpress_id: 659
@@ -13,7 +8,7 @@ cover: sarunas-marciulionis.jpg
 date: 2010-07-24 15:24:16 +0200
 ---
 
-[Rony Seikaly](http://en.wikipedia.org/wiki/Rony_Seikaly] est
-[DJ->http://www.thetripwire.com/news/2010/07/23/rony-seikaly-will-now-be-making-some-music-news-thank-you)
+[Rony Seikaly](http://en.wikipedia.org/wiki/Rony_Seikaly) est
+[DJ](http://www.thetripwire.com/news/2010/07/23/rony-seikaly-will-now-be-making-some-music-news-thank-you)
 ? Peut-être mais moi, j'attends toujours un concert de Šarūnas Marčiulionis ! Le
 monde va mal !

--- a/2010/2010-07-25-le-gang-des-pigeons-a-encore-frappe.md
+++ b/2010/2010-07-25-le-gang-des-pigeons-a-encore-frappe.md
@@ -1,10 +1,6 @@
 ---
 layout: post
 title: Le gang des pigeons a encore frappé
-description:
-  "[Les Kings of Leon ont dû arrêter un de leurs concerts car ils se sont faits
-  attaquer… par des fientes de
-  pigeon.->http://www.nme.com/news/kings-of-leon/52204] Le monde va mal !"
 authors:
   - Dirty Henry
 wordpress_id: 661

--- a/2010/2010-08-10-plus-besoin-de-diplomes.md
+++ b/2010/2010-08-10-plus-besoin-de-diplomes.md
@@ -1,11 +1,6 @@
 ---
 layout: post
 title: Plus besoin de diplômes !
-description:
-  Quitte à manquer de légitimité, vu que [Jason Bonham a déclaré avoir failli
-  reformer Led Zeppelin sans Robert
-  Plant->http://www.nme.com/news/led-zeppelin/52004], pourquoi personne n'a
-  pensé à reformer les Beatles ? Le monde va mal !
 authors:
   - Dirty Henry
 wordpress_id: 677

--- a/2010/2010-08-12-clip-de-the-daredevil-christopher-wright.md
+++ b/2010/2010-08-12-clip-de-the-daredevil-christopher-wright.md
@@ -24,7 +24,7 @@ et nous a récemment diffusé le clip ci-dessous, très beau, et que je rediffus
 mon tour. On se voit le 18 !
 
 [edit : ah merde, en fait le concert du 18 est un [happening
-événementiel](http://7ciel.net/concerts/] et pour avoir des places, il faudra
+événementiel](http://7ciel.net/concerts/) et pour avoir des places, il faudra
 les gagner sur [ce site](http://www.popnews.com/) à partir du 28 août…)
 
 <object width="500" height="375"><param name="allowfullscreen" value="true" /><param name="allowscriptaccess" value="always" /><param name="movie" value="http://vimeo.com/moogaloop.swf?clip_id=13206073&server=vimeo.com&show_title=0&show_byline=0&show_portrait=0&color=59a5d1&fullscreen=1&autoplay=0&loop=0" /><embed src="http://vimeo.com/moogaloop.swf?clip_id=13206073&server=vimeo.com&show_title=0&show_byline=0&show_portrait=0&color=59a5d1&fullscreen=1&autoplay=0&loop=0" type="application/x-shockwave-flash" allowfullscreen="true" allowscriptaccess="always" width="500" height="375"></embed></object>

--- a/2010/2010-08-12-clip-de-the-daredevil-christopher-wright.md
+++ b/2010/2010-08-12-clip-de-the-daredevil-christopher-wright.md
@@ -23,8 +23,9 @@ Pourquoi ? La Blogothèque avait passé un titre en juillet
 et nous a récemment diffusé le clip ci-dessous, très beau, et que je rediffuse à
 mon tour. On se voit le 18 !
 
-[edit : ah merde, en fait le concert du 18 est un [happening
-événementiel](http://7ciel.net/concerts/) et pour avoir des places, il faudra
-les gagner sur [ce site](http://www.popnews.com/) à partir du 28 août…)
+[edit : ah merde, en fait le concert du 18 est un
+[happening événementiel](http://7ciel.net/concerts/) et pour avoir des places,
+il faudra les gagner sur [ce site](http://www.popnews.com/) à partir du 28
+août…)
 
 <object width="500" height="375"><param name="allowfullscreen" value="true" /><param name="allowscriptaccess" value="always" /><param name="movie" value="http://vimeo.com/moogaloop.swf?clip_id=13206073&server=vimeo.com&show_title=0&show_byline=0&show_portrait=0&color=59a5d1&fullscreen=1&autoplay=0&loop=0" /><embed src="http://vimeo.com/moogaloop.swf?clip_id=13206073&server=vimeo.com&show_title=0&show_byline=0&show_portrait=0&color=59a5d1&fullscreen=1&autoplay=0&loop=0" type="application/x-shockwave-flash" allowfullscreen="true" allowscriptaccess="always" width="500" height="375"></embed></object>

--- a/2010/2010-08-27-neutral-uke-hotel-in-the-aeroplane-over-the-sea-neutral-milk-hotel.md
+++ b/2010/2010-08-27-neutral-uke-hotel-in-the-aeroplane-over-the-sea-neutral-milk-hotel.md
@@ -1,11 +1,6 @@
 ---
 layout: post
 title: Neutral Uke Hotel - In The Aeroplane Over The Sea (Neutral Milk Hotel)
-description:
-  Encore une reprise de Neutral Milk Hotel, jouée cette fois au Ukulele, par un
-  groupe où figure le fils caché de [Groucho
-  Marx](http://www.google.fr/images?q=groucho) et de [Nicolas le
-  jardinier](http://www.google.fr/images?q=nicolas le jardinier).
 authors:
   - Dirty Henry
 wordpress_id: 687
@@ -14,11 +9,13 @@ date: 2010-08-27 12:07:19 +0200
 ---
 
 Encore une reprise de Neutral Milk Hotel, jouée cette fois au Ukulele, par un
-groupe où figure le fils caché de [Groucho
-Marx](http://www.google.fr/images?q=groucho] et de [Nicolas le
-jardinier->http://www.google.fr/images?q=nicolas le jardinier).
+groupe où figure le fils caché de
+[Groucho Marx](http://www.google.fr/images?q=groucho) et de [Nicolas le
+jardinier][1].
 
 {% vimeo 14408837 %}
 
 (via
 [la Blogothèque](http://www.blogotheque.net/NxNE-Blogotheque-Series-Part-Two))
+
+[1]: https://www.google.fr/search?q=nicolas+le+jardinier&tbm=isch

--- a/2010/2010-08-31-les-raveonettes-reprennent-les-stone-roses.md
+++ b/2010/2010-08-31-les-raveonettes-reprennent-les-stone-roses.md
@@ -18,8 +18,8 @@ tags:
   - The Raveonettes
 ---
 
-Les reprises sont à la mode ! Après Levis et ses [Pioneer Sessions](623], Beck
-et son [record club](br26), le AV Club et son [Undercover->680), c'est au tour
+Les reprises sont à la mode ! Après Levis et ses [Pioneer Sessions](623), Beck
+et son [record club](br26), le AV Club et son [Undercover](680), c'est au tour
 de Doc Martens de créer sa collec' de reprises pour fêter ses 50 ans.
 
 Duke Spirit, Black Rebel Motorcycle Club sont au programme, ainsi que les

--- a/2010/2010-09-02-un-parfum-qui-pue-meme-pas.md
+++ b/2010/2010-09-02-un-parfum-qui-pue-meme-pas.md
@@ -16,5 +16,5 @@ tags:
 Et il ne sent même pas un mélange de sueur, de sang et de crottes de nez. Le
 monde va mal !
 
-(photo par [lupinehorror](http://www.flickr.com/photos/lupinehorror/] sous
-[licence CC-BY-NC->http://creativecommons.org/licenses/by-nc/2.0/))
+(photo par [lupinehorror](http://www.flickr.com/photos/lupinehorror/) sous
+[licence CC-BY-NC](http://creativecommons.org/licenses/by-nc/2.0/))

--- a/2010/2010-09-24-ton-grand-pere-et-ses-chiens-indiana-jones-james-mercer-et-des-metalleux-jouent-au-tir-a-la-corde.md
+++ b/2010/2010-09-24-ton-grand-pere-et-ses-chiens-indiana-jones-james-mercer-et-des-metalleux-jouent-au-tir-a-la-corde.md
@@ -28,7 +28,7 @@ chiens, Indiana Jones, James Mercer et des métalleux jouent au tir à la corde.
 <img388>
 
 (licence Creative Commons à
-[fixedgear](http://www.flickr.com/photos/fixedgear/4159465921/], via
+[fixedgear](http://www.flickr.com/photos/fixedgear/4159465921/), via
 [Flowing Data](http://flowingdata.com/2010/09/17/venn-your-grandfather/))
 
 ## Guide du clip à buzz

--- a/2010/2010-09-24-ton-grand-pere-et-ses-chiens-indiana-jones-james-mercer-et-des-metalleux-jouent-au-tir-a-la-corde.md
+++ b/2010/2010-09-24-ton-grand-pere-et-ses-chiens-indiana-jones-james-mercer-et-des-metalleux-jouent-au-tir-a-la-corde.md
@@ -28,8 +28,8 @@ chiens, Indiana Jones, James Mercer et des métalleux jouent au tir à la corde.
 <img388>
 
 (licence Creative Commons à
-[fixedgear](http://www.flickr.com/photos/fixedgear/4159465921/], via [Flowing
-Data->http://flowingdata.com/2010/09/17/venn-your-grandfather/))
+[fixedgear](http://www.flickr.com/photos/fixedgear/4159465921/], via
+[Flowing Data](http://flowingdata.com/2010/09/17/venn-your-grandfather/))
 
 ## Guide du clip à buzz
 

--- a/2010/2010-10-01-la-tele-privee-des-nenes-de-katy-perry.md
+++ b/2010/2010-10-01-la-tele-privee-des-nenes-de-katy-perry.md
@@ -1,13 +1,6 @@
 ---
 layout: post
 title: La télé privée des nénés de Katy Perry
-description:
-  "[Les producteurs de Rue Sésame ont décidé de censurer la participation de
-  Katy Perry à l'émission prévue pour le nouvel an à cause d'une robe au
-  décolleté trop olé olé…->http://www.nme.com/news/katy-perry/53135]
-  Heureusement qu'en France, on aura toujours la retransmission d'un spectacle
-  du Crazy Horse à la St-Sylvestre, mais ils vont se faire aux States ! Le monde
-  va mal !"
 authors:
   - Dirty Henry
 wordpress_id: 707

--- a/2010/2010-10-05-barat-defend-l-indefendable.md
+++ b/2010/2010-10-05-barat-defend-l-indefendable.md
@@ -1,10 +1,6 @@
 ---
 layout: post
 title: Barât défend l'indéfendable
-description:
-  L'ex-Libertine et Dirty Pretty Things le clame haut et fort :[ "non, la
-  pochette de mon disque solo n'est pas
-  moche"->http://www.nme.com/news/carl-barat/53280]. Le monde va mal !
 authors:
   - Dirty Henry
 wordpress_id: 710

--- a/2010/2010-10-08-liberation-generale.md
+++ b/2010/2010-10-08-liberation-generale.md
@@ -27,13 +27,12 @@ La preuve :
 
 ## 2. La France est libérée
 
-[*Le Retour à la
-Terre*](http://fr.wikipedia.org/wiki/Le_Retour_%C3%A0_la_terre], c'est marrant.
-[*De Gaulle* par
-Ferri->http://www.amazon.fr/Gaulle-%C3%A0-plage-Jean-Yves-Ferri/dp/2205059661],
-c'est marrant. [Le mélange des
-deux->http://www.manularcenet.com/blog/articles/4016/piratage), c'est donc
-marrant aussi.
+[_Le Retour à la Terre_](http://fr.wikipedia.org/wiki/Le_Retour_%C3%A0_la_terre),
+c'est marrant.
+[_De Gaulle_ par Ferri](http://www.amazon.fr/Gaulle-%C3%A0-plage-Jean-Yves-Ferri/dp/2205059661),
+c'est marrant.
+[Le mélange des deux](http://www.manularcenet.com/blog/articles/4016/piratage),
+c'est donc marrant aussi.
 
 ## 3. Les urbanistes de Floride sont libérés
 

--- a/2010/2010-10-15-de-la-biere-et-du-foot-de-la-musique-et-un-chien.md
+++ b/2010/2010-10-15-de-la-biere-et-du-foot-de-la-musique-et-un-chien.md
@@ -60,18 +60,18 @@ leurs propositions : _If You See Me Holding A Gun, Da Doo Ron Ron: The Story Of
 Phil Spector_.
 
 (via
-[Stereogum](http://stereogum.com/513961/sacha-baron-cohen-cast-as-freddie-mercury/casting-couch/]
+[Stereogum](http://stereogum.com/513961/sacha-baron-cohen-cast-as-freddie-mercury/casting-couch/)
 et…
-[Stereogum->http://stereogum.com/540682/name-the-phil-spector-biopic-starring-al-pacin/casting-couch/))
+[Stereogum](http://stereogum.com/540682/name-the-phil-spector-biopic-starring-al-pacin/casting-couch/))
 
 ## 3. Continuons à chercher des noms
 
-Les [générateurs](http://www.nukekiller.net/cgi-bin/namer.cgi] de
+Les [générateurs](http://www.nukekiller.net/cgi-bin/namer.cgi) de
 [nom](http://www.bandnamemaker.com/generator/) de
 [groupes](http://www.noiseaddicts.com/2009/03/random-band-name-cover-album/) (et
-de [boîtes à aimer->http://www.dotomator.com/web20.html]) ont fait légion ces
-dernières années, [ce dernier arrivé est pas mal non
-plus->http://chillwitchnamemagic.com/).
+de [boîtes à aimer](http://www.dotomator.com/web20.html]) ont fait légion ces
+dernières années,
+[ce dernier arrivé est pas mal non plus](http://chillwitchnamemagic.com/).
 
 ## 4. Causons foot
 

--- a/2010/2010-10-15-de-la-biere-et-du-foot-de-la-musique-et-un-chien.md
+++ b/2010/2010-10-15-de-la-biere-et-du-foot-de-la-musique-et-un-chien.md
@@ -69,7 +69,7 @@ et…
 Les [générateurs](http://www.nukekiller.net/cgi-bin/namer.cgi) de
 [nom](http://www.bandnamemaker.com/generator/) de
 [groupes](http://www.noiseaddicts.com/2009/03/random-band-name-cover-album/) (et
-de [boîtes à aimer](http://www.dotomator.com/web20.html]) ont fait légion ces
+de [boîtes à aimer](http://www.dotomator.com/web20.html)) ont fait légion ces
 dernières années,
 [ce dernier arrivé est pas mal non plus](http://chillwitchnamemagic.com/).
 

--- a/2010/2010-10-20-follow-up-freelance-whales.md
+++ b/2010/2010-10-20-follow-up-freelance-whales.md
@@ -14,7 +14,7 @@ tags:
   - Vidéo Clip
 ---
 
-Je vous avais parlé des **Freelance Whales** [ici](594], ils nous offraient
+Je vous avais parlé des **Freelance Whales** [ici](594), ils nous offraient
 alors un titre génial, _Generator ^ Second Floor_. Depuis, un album complet est
 sorti : il s'appelle _Weathervanes_, est écoutable en intégralité sur
 [Spotify](http://open.spotify.com/album/4XYtSHEBqUnYbxJ5q3pCze) et

--- a/2010/2010-10-20-follow-up-freelance-whales.md
+++ b/2010/2010-10-20-follow-up-freelance-whales.md
@@ -17,8 +17,8 @@ tags:
 Je vous avais parlé des **Freelance Whales** [ici](594], ils nous offraient
 alors un titre génial, _Generator ^ Second Floor_. Depuis, un album complet est
 sorti : il s'appelle _Weathervanes_, est écoutable en intégralité sur
-[Spotify](http://open.spotify.com/album/4XYtSHEBqUnYbxJ5q3pCze) et [se fait
-défoncer sur Pitchfork->http://pitchfork.com/reviews/albums/13955-weathervanes/)
+[Spotify](http://open.spotify.com/album/4XYtSHEBqUnYbxJ5q3pCze) et
+[se fait défoncer sur Pitchfork](http://pitchfork.com/reviews/albums/13955-weathervanes/)
 (c'est pas forcément mauvais signe) qui accuse le groupe de "maniérisme cucul
 sans but réel".
 

--- a/2010/2010-10-21-detroit-rock-roll.md
+++ b/2010/2010-10-21-detroit-rock-roll.md
@@ -48,14 +48,14 @@ d’adoption. Même si j’y ai grandi 20 ans après que l’endroit ait (litté
 explosé, c’est la musique et l’environnement avec lesquels j’ai grandi. La
 Motown passe toujours sur presque toutes les stations de radio du Michigan, et
 les magasins de disques d’occasion sont remplis de vinyls de
-[Fortune](http://en.wikipedia.org/wiki/Fortune_Records] ou de copies bien usées
-de [*Kick Out The Jams*->http://fr.wikipedia.org/wiki/Kick_Out_the_Jams].
+[Fortune](http://en.wikipedia.org/wiki/Fortune_Records) ou de copies bien usées
+de [_Kick Out The Jams_](http://fr.wikipedia.org/wiki/Kick_Out_the_Jams).
 Detroit n’a jamais bénéficié de «renaissance» et les conséquences des émeutes
 n’ont jamais été aussi profondes. Mais il y a toujours cette sensation
 d’aventure urbaine que [John Sinclair][1] décrit dans le documentaire. Sinclair
 a toujours été un de mes héros : son parti des
 [White Panther](http://en.wikipedia.org/wiki/White_Panther_Party) a influencé
-mon groupe, les [Soledad Brothers->215), et il a écrit les notes de pochettes de
+mon groupe, les [Soledad Brothers](215), et il a écrit les notes de pochettes de
 mon premier album.
 
 Alors pourquoi Detroit continue de pondre le meilleur rock’n’roll ? A bien des

--- a/2010/2010-10-29-fun-friday-07.md
+++ b/2010/2010-10-29-fun-friday-07.md
@@ -42,8 +42,8 @@ Un diagramme de Venn pense-bête bien utile…
 
 <img446>
 
-([buriednexttoyou](http://www.flickr.com/photos/buriednexttoyou/5095255302/] via
-[flowingdata->http://flowingdata.com/2010/10/22/privacy-and-the-internet/))
+([buriednexttoyou](http://www.flickr.com/photos/buriednexttoyou/5095255302/) via
+[flowingdata](http://flowingdata.com/2010/10/22/privacy-and-the-internet/))
 
 ## 4. Le juste mot
 

--- a/2011/2011-01-15-top-music-2010.md
+++ b/2011/2011-01-15-top-music-2010.md
@@ -86,7 +86,7 @@ Special Mentions:
 The First Place spots for 2001 to 2009 are all taken. The National is therefore
 the last group to join the clan of the top of the 00’s[[some people think the
 decade runs from 2000-2009, not 2001-2010…
-[But it's false](http://www2.saf-lastronomie.com/siecle.htm]]), which as a brief
+[But it's false](http://www2.saf-lastronomie.com/siecle.htm)]), which as a brief
 reminder, is the following:
 
 - 2001. The Strokes - _Is This It_

--- a/2011/2011-01-25-et-apres-bill-russell-au-psg.md
+++ b/2011/2011-01-25-et-apres-bill-russell-au-psg.md
@@ -8,9 +8,8 @@ cover: wilt-chamberlain-lakers.jpg
 date: 2011-01-25 09:07:09 +0100
 ---
 
-[Arsenal envisage d'engager
-Chamberlain](http://www.lequipe.fr/Football/20110124_114042_chamberlain-proche-d-arsenal.html].
-Pas sûr cependant que [le grand
-Wilt->http://fr.wikipedia.org/wiki/Wilt_Chamberlain) arrivera à marquer 100 buts
-dans un match de foot comme il avait marqué 100 pts dans un match de basket.
-D'autant qu'il est mort en 1999. Le monde va mal !
+[Arsenal envisage d'engager Chamberlain](http://www.lequipe.fr/Football/20110124_114042_chamberlain-proche-d-arsenal.html).
+Pas sûr cependant que
+[le grand Wilt](http://fr.wikipedia.org/wiki/Wilt_Chamberlain) arrivera à
+marquer 100 buts dans un match de foot comme il avait marqué 100 pts dans un
+match de basket. D'autant qu'il est mort en 1999. Le monde va mal !

--- a/2011/2011-02-11-fun-friday-08.md
+++ b/2011/2011-02-11-fun-friday-08.md
@@ -18,7 +18,7 @@ tags:
 ## 1. Redorons l'image de la France ! Déterrons ses héros !
 
 Connaissez-vous M. Mangetout ? J'ai découvert M. Mangetout grâce au site
-[Learn Something Every Day](http://www.learnsomethingeveryday.co.uk/#/2010/11/06] "pour lequel les affaires marchent fort : ils ont une [application iPhone)(http://itunes.apple.com/fr/app/learn-something-every-day/id403233770?mt=8) et [un livre en précommande](http://www.amazon.com/Learn-Something-Every-Day-Young/dp/0399536663")
+[Learn Something Every Day](http://www.learnsomethingeveryday.co.uk/#/2010/11/06) "pour lequel les affaires marchent fort : ils ont une [application iPhone)(http://itunes.apple.com/fr/app/learn-something-every-day/id403233770?mt=8) et [un livre en précommande](http://www.amazon.com/Learn-Something-Every-Day-Young/dp/0399536663")
 :
 
 <img464>

--- a/2011/2011-02-11-fun-friday-08.md
+++ b/2011/2011-02-11-fun-friday-08.md
@@ -18,7 +18,7 @@ tags:
 ## 1. Redorons l'image de la France ! Déterrons ses héros !
 
 Connaissez-vous M. Mangetout ? J'ai découvert M. Mangetout grâce au site
-[Learn Something Every Day](http://www.learnsomethingeveryday.co.uk/#/2010/11/06) "pour lequel les affaires marchent fort : ils ont une [application iPhone)(http://itunes.apple.com/fr/app/learn-something-every-day/id403233770?mt=8) et [un livre en précommande](http://www.amazon.com/Learn-Something-Every-Day-Young/dp/0399536663")
+[Learn Something Every Day](http://www.learnsomethingeveryday.co.uk/#/2010/11/06) "pour lequel les affaires marchent fort : ils ont une [application iPhone](http://itunes.apple.com/fr/app/learn-something-every-day/id403233770?mt=8) et [un livre en précommande](http://www.amazon.com/Learn-Something-Every-Day-Young/dp/0399536663")
 :
 
 <img464>

--- a/2011/2011-02-11-fun-friday-08.md
+++ b/2011/2011-02-11-fun-friday-08.md
@@ -18,7 +18,11 @@ tags:
 ## 1. Redorons l'image de la France ! Déterrons ses héros !
 
 Connaissez-vous M. Mangetout ? J'ai découvert M. Mangetout grâce au site
-[Learn Something Every Day](http://www.learnsomethingeveryday.co.uk/#/2010/11/06) "pour lequel les affaires marchent fort : ils ont une [application iPhone](http://itunes.apple.com/fr/app/learn-something-every-day/id403233770?mt=8) et [un livre en précommande](http://www.amazon.com/Learn-Something-Every-Day-Young/dp/0399536663")
+[Learn Something Every Day](http://www.learnsomethingeveryday.co.uk/#/2010/11/06)
+"pour lequel les affaires marchent fort : ils ont une
+[application iPhone](http://itunes.apple.com/fr/app/learn-something-every-day/id403233770?mt=8)
+et
+[un livre en précommande](http://www.amazon.com/Learn-Something-Every-Day-Young/dp/0399536663")
 :
 
 <img464>

--- a/2011/2011-02-17-cine-club-moi-j-vous-dis-03.md
+++ b/2011/2011-02-17-cine-club-moi-j-vous-dis-03.md
@@ -114,12 +114,10 @@ Fantomas, qu'on peut trouver
 ## Les autres
 
 - _L'année du dragon_ - Michael Cimino (1985) : remake du Parrain où on remplace
-  la Sicile par la Chine, le film prouve surtout que [Mickey Rourke et Bruce
-  Willis sont une seule et même
-  personne](http://cheezburger.com/jibe/lolz/View/1353215232], que certains
-  intérieurs new-yorkais ont vraiment la classe et que [certains looks des 80s
-  n'étaient ni faits ni à
-  faire->http://www.imdb.com/media/rm914397696/tt0090350)
+  la Sicile par la Chine, le film prouve surtout que
+  [Mickey Rourke et Bruce Willis sont une seule et même personne](http://cheezburger.com/jibe/lolz/View/1353215232),
+  que certains intérieurs new-yorkais ont vraiment la classe et que
+  [certains looks des 80s n'étaient ni faits ni à faire](http://www.imdb.com/media/rm914397696/tt0090350)
 - _Definitely Maybe_ - Adam Brooks (2008) : film qu'on regarde parce qu'on pense
   qu'il y aura un rapport avec Oasis mais en fait non, il s'agit d'une comédie
   romantique avec un scénario original (un père raconte sa vie amoureuse d'il y

--- a/2011/2011-03-03-la-vie-tres-privee-de-mr-sim-de-jonathan-coe.md
+++ b/2011/2011-03-03-la-vie-tres-privee-de-mr-sim-de-jonathan-coe.md
@@ -39,12 +39,11 @@ Avant de continuer, parlons un petit peu de l'auteur. **Jonathan Coe** est un
 auteur britannique de 50 ans, originaire de Birmingham, surtout connu pour trois
 ouvrages :
 
-- [*Testament à
-  l'anglaise*](http://fr.wikipedia.org/wiki/Testament_%C3%A0_l'anglaise] (_What
-  A Carve Up!_ en V.O.), satire policière pleine d'humour noir sur la société
-  anglaise des années 80 marquée par cette bonne vieille Maggie Thatcher (à ne
-  pas confondre avec [Maguy tout court, qui voit souvent
-  rouge->http://www.dailymotion.com/video/x383g_maguy_music)),
+- [_Testament à l'anglaise_](http://fr.wikipedia.org/wiki/Testament_%C3%A0_l'anglaise)
+  (_What A Carve Up!_ en V.O.), satire policière pleine d'humour noir sur la
+  société anglaise des années 80 marquée par cette bonne vieille Maggie Thatcher
+  (à ne pas confondre avec
+  [Maguy tout court, qui voit souvent rouge](http://www.dailymotion.com/video/x383g_maguy_music)),
 - le diptyque _Bienvenue au Club/Le Cercle Fermé_ (_The Rotters' Club/The Closed
   Circle_), au sommet de mon panthéon personnel et que je recommande tout
   particulièrement, qui traite de la petite histoire d'un groupe d'adolescents

--- a/2011/2011-03-25-fun-friday-09.md
+++ b/2011/2011-03-25-fun-friday-09.md
@@ -26,17 +26,17 @@ secrète.
 **{Les pochettes de disque**}
 
 Il y a tout d'abord de nombreuses reconstitutions de pochettes de disques en
-LEGO : [hip-hop](http://www.formatmag.com/features/lego-hip-hop-album-covers/],
-[rock'n'roll->http://www.thetoyzone.com/2008/20-album-covers-recreated-in-lego/),
+LEGO : [hip-hop](http://www.formatmag.com/features/lego-hip-hop-album-covers/),
+[rock'n'roll](http://www.thetoyzone.com/2008/20-album-covers-recreated-in-lego/),
 tous les styles y passent.
 
-Mieux, un groupe Flickr, [LEGO Album
-Covers](http://www.flickr.com/groups/lego_album_covers/], propose de rassembler
-tous les efforts des artistes qui se sont lancés dans cet exercice de style. Mes
-préférées sont pour la plupart signées Christoph, du
+Mieux, un groupe Flickr,
+[LEGO Album Covers](http://www.flickr.com/groups/lego_album_covers/), propose de
+rassembler tous les efforts des artistes qui se sont lancés dans cet exercice de
+style. Mes préférées sont pour la plupart signées Christoph, du
 [site de chroniques de concerts en France et en Allemagne Konzerttagebuch](http://www.konzerttagebuch.de/),
-qu'il m'a gentiment autorisé à diffuser ici [[ces illustrations sont protégées
-par copyright par [Christoph!->http://www.flickr.com/photos/-christoph-/]]) :
+qu'il m'a gentiment autorisé à diffuser ici (ces illustrations sont protégées
+par copyright par [Christoph!](http://www.flickr.com/photos/-christoph-/)) :
 
 <img469>
 
@@ -57,8 +57,8 @@ _Transmission_. La chorégraphie de Ian Curtis est très bien reproduite. Epique
 **Edit** : je remarque avec effroi qu'il ne s'agit pas de LEGO mais de
 Playmobil… Je suis devenu un vieux con qui ne voit pas la différence entre les
 deux on dirait. Mais les LEGO en stop-motion, il y en a
-[vraiment](http://www.youtube.com/watch?v=_whyjdt5Qso]
-[beaucoup->http://www.youtube.com/watch?v=iOTYCmXjZSU) par contre…
+[vraiment](http://www.youtube.com/watch?v=_whyjdt5Qso)
+[beaucoup](http://www.youtube.com/watch?v=iOTYCmXjZSU) par contre…
 
 {% youtube _UQmY57qrfw %}
 
@@ -70,12 +70,12 @@ Stripes, avec des LEGO uniquement.
 **{Les jeux-vidéo**}
 
 Moins fun dans l'âme mais quand même, le jeu vidéo Rock Band a décliné une
-édition LEGO, dans lequel des avatars d'I[ggy
-Pop](http://www.google.fr/images?q=iggy+pop+lego+rock+band],
+édition LEGO, dans lequel des avatars
+d'I[ggy Pop](http://www.google.fr/images?q=iggy+pop+lego+rock+band),
 [Bowie](http://www.google.fr/images?q=bowie+lego+rock+band),
 [Blur](http://www.google.fr/images?q=blur+lego+rock+band),
-[Queen](http://www.google.fr/images?q=queen+lego+rock+band) ou [Spinal
-Tap->http://www.google.fr/images?q=spinal+tap+lego+rock+band) ont été
+[Queen](http://www.google.fr/images?q=queen+lego+rock+band) ou
+[Spinal Tap](http://www.google.fr/images?q=spinal+tap+lego+rock+band) ont été
 introduits.
 
 {% youtube W-gYly6Rqi4 %}

--- a/2011/2011-04-05-keren-ann-101.md
+++ b/2011/2011-04-05-keren-ann-101.md
@@ -26,7 +26,7 @@ rare, serait-ce _101_ ?
 
 Les premières bribes d'informations sur l'album n'incitaient pas à un optimisme
 aveugle. D'abord, Keren Ann affichait une coiffure que les plus branchouilles
-loueraient comme [karenoesque](http://www.google.fr/images?q=karen+o] mais
+loueraient comme [karenoesque](http://www.google.fr/images?q=karen+o) mais
 qu'honnêtement, on qualifierait plutôt de
 [mireillemathieuesque](http://www.google.fr/images?q=mireille+mathieu). Un
 [article sur le web](http://next.liberation.fr/culture/01012323991-keren-ann-sacre-numero)
@@ -34,17 +34,17 @@ nous a depuis rassuré d'un «Nul saccage capillaire n’est non plus à déplor
 (en fait, ses cheveux sont dissimulés sous une perruque) mais l'esthétique
 général est lui aussi d'assez mauvais goût, s'inspirant peut-être d'une ambiance
 de voyou élégant genre _Bonnie And Clyde_ mais échouant plutôt vers
-_[Tao->http://www.google.fr/images?q=tao+cit%C3%A9s+d%27or) chez les loulous_.
+_[Tao](http://www.google.fr/images?q=tao+cit%C3%A9s+d%27or) chez les loulous_.
 
 En outre, le single ayant précédé l'album (et qui ouvre les débats sur _101_),
-[*My Name Is Trouble*](795], tout comme [la vidéo qui va avec->795],
+[_My Name Is Trouble_](795), tout comme [la vidéo qui va avec](795),
 m'inquiétaient au plus haut point. Certes, je peux, dans des circonstances
-exceptionnelles, aimer la disco. Par exemple quand on me demande de [shaker mon
-booty->http://www.youtube.com/watch?v=Kb2_eo9lBCY). Mais quand c'est Keren Ann
-qui s'y colle, mes oreilles frissonnent d'angoisse : intime et touchante dans
-son registre folk habituel, sa voix devient hautaine et dédaigneuse lorsqu'elle
-se pose sur ce disco de bas étage. Keren Ann tient désormais son _Miss You_,
-mais faut-il s'en réjouir ?
+exceptionnelles, aimer la disco. Par exemple quand on me demande de
+[shaker mon booty](http://www.youtube.com/watch?v=Kb2_eo9lBCY). Mais quand c'est
+Keren Ann qui s'y colle, mes oreilles frissonnent d'angoisse : intime et
+touchante dans son registre folk habituel, sa voix devient hautaine et
+dédaigneuse lorsqu'elle se pose sur ce disco de bas étage. Keren Ann tient
+désormais son _Miss You_, mais faut-il s'en réjouir ?
 
 <img477>
 

--- a/2011/2011-04-05-keren-ann-101.md
+++ b/2011/2011-04-05-keren-ann-101.md
@@ -69,11 +69,12 @@ réussie.
 <img476>
 
 Après le disco des Stones et la funk de Lipps Inc., Keren Ann continue son
-hommage à la musique américaine[[[l'encyclopédie approximative du
-rock'n'roll](rub26) vous le confirmera un jour, les Rolling Stones devinrent
-américains à partir de 1978]) en citant le _Everybody's Talkin'_ d'Harry Nilsson
-sur _She Won't Trade It For Nothing_, ou <strike>le _Blowin' in the wind_
-de</strike> **reprenant** Dylan sur _Daddy, You Been On My Mind_.
+hommage à la musique
+américaine[[[l'encyclopédie approximative du rock'n'roll](rub26) vous le
+confirmera un jour, les Rolling Stones devinrent américains à partir de 1978])
+en citant le _Everybody's Talkin'_ d'Harry Nilsson sur _She Won't Trade It For
+Nothing_, ou <strike>le _Blowin' in the wind_ de</strike> **reprenant** Dylan
+sur _Daddy, You Been On My Mind_.
 
 Mais Keren Ann n'est jamais aussi forte que lorsqu'elle touche la corde sensible
 et c'est finalement _Strange Weather_ qui me semble le meilleur titre de l'album

--- a/2011/2011-04-05-keren-ann-101.md
+++ b/2011/2011-04-05-keren-ann-101.md
@@ -70,7 +70,7 @@ réussie.
 
 Après le disco des Stones et la funk de Lipps Inc., Keren Ann continue son
 hommage à la musique américaine[[[l'encyclopédie approximative du
-rock'n'roll](rub26] vous le confirmera un jour, les Rolling Stones devinrent
+rock'n'roll](rub26) vous le confirmera un jour, les Rolling Stones devinrent
 américains à partir de 1978]) en citant le _Everybody's Talkin'_ d'Harry Nilsson
 sur _She Won't Trade It For Nothing_, ou <strike>le _Blowin' in the wind_
 de</strike> **reprenant** Dylan sur _Daddy, You Been On My Mind_.

--- a/2011/2011-04-12-cine-club-moi-j-vous-dis-05.md
+++ b/2011/2011-04-12-cine-club-moi-j-vous-dis-05.md
@@ -81,24 +81,23 @@ s'assurer que Gino est un chef redouté avant de lui transmettre sa part
 d'héritage. Gino décide alors de tourner un documentaire sur sa fausse vie de
 parrain des pizzerias de Bruxelles.
 
-L'état d'esprit est ici très similaire à celui de [*J'ai toujours rêvé d'être un
-gangster*](http://www.allocine.fr/film/fichefilm_gen_cfilm=110966.html], le
-précédent film de Benchetrit, lui aussi très bon. C'est une sorte de [*Soyez
-sympas,
-rembobinez*->http://www.allocine.fr/film/fichefilm_gen_cfilm=110281.html]
-refaisant [*Le
-Parrain*->http://www.allocine.fr/film/fichefilm_gen_cfilm=1628.html] à la sauce
-[*C'est arrivé près de chez
-vous*->http://www.allocine.fr/film/fichefilm_gen_cfilm=7383.html] : le cadre et
-l'ambiance lose font très "cinéma belge" et rappellent également les passages
-plus potaches que glauques des films de
-[Delépine->http://www.allocine.fr/personne/fichepersonne_gen_cpersonne=2389.html]
+L'état d'esprit est ici très similaire à celui de
+[_J'ai toujours rêvé d'être un gangster_](http://www.allocine.fr/film/fichefilm_gen_cfilm=110966.html),
+le précédent film de Benchetrit, lui aussi très bon. C'est une sorte de
+[_Soyez sympas, rembobinez_](http://www.allocine.fr/film/fichefilm_gen_cfilm=110281.html)
+refaisant
+[_Le Parrain_](http://www.allocine.fr/film/fichefilm_gen_cfilm=1628.html) à la
+sauce
+[_C'est arrivé près de chez vous_](http://www.allocine.fr/film/fichefilm_gen_cfilm=7383.html)
+: le cadre et l'ambiance lose font très "cinéma belge" et rappellent également
+les passages plus potaches que glauques des films de
+[Delépine](http://www.allocine.fr/personne/fichepersonne_gen_cpersonne=2389.html)
 et
 [Kervern](http://www.allocine.fr/personne/fichepersonne_gen_cpersonne=97326.html).
 Malgré quelques lenteurs et quelques malaises dûs aux acteurs (Anna Mouglalis
 n'est pas au top dans des rôles comiques), le film reste très drôle. Benchetrit
 aime aussi beaucoup citer les petits copains et son film est en fait un chouette
-hommage au cinéma, façon [DIY->http://fr.wikipedia.org/wiki/Do_it_yourself).
+hommage au cinéma, façon [DIY](http://fr.wikipedia.org/wiki/Do_it_yourself).
 
 **<strike>La musique</strike> Le sketch qui va avec**
 

--- a/2011/2011-04-21-the-diy-series-social-square.md
+++ b/2011/2011-04-21-the-diy-series-social-square.md
@@ -61,14 +61,14 @@ La seconde, je vous la révélerai tout à l'heure.
 Pas de home-studio pour Social Square, les chansons sont donc travaillées live.
 Pour répéter, Social Square a trouvé un bon filon. Plutôt que disposer d'un
 créneau dans un studio qu'on loue à l'heure ou à la journée (type
-[Basement](http://www.basementprod.com/], [Luna
-Rossa->http://www.studiolunarossa.com/) ou autre), ils jouent dans un local loué
-en commun par plusieurs groupes à St-Ouen. Du coup, ça coûte a priori moins
-cher, mais ça a surtout l'avantage d'être plus facile pour avoir son créneau
-hebdomadaire (le lundi c'est la soirée Social Square pour chacun des membres du
-groupe) et plus pratique pour laisser son matériel. Soit, il reste toujours le
-problème du matos qu'on doit partager entre groupes (batterie et amplis) mais
-c'est un moindre mal.
+[Basement](http://www.basementprod.com/),
+[Luna Rossa](http://www.studiolunarossa.com/) ou autre), ils jouent dans un
+local loué en commun par plusieurs groupes à St-Ouen. Du coup, ça coûte a priori
+moins cher, mais ça a surtout l'avantage d'être plus facile pour avoir son
+créneau hebdomadaire (le lundi c'est la soirée Social Square pour chacun des
+membres du groupe) et plus pratique pour laisser son matériel. Soit, il reste
+toujours le problème du matos qu'on doit partager entre groupes (batterie et
+amplis) mais c'est un moindre mal.
 
 **{Les enregistrements**}
 
@@ -85,10 +85,9 @@ faits sans exploser le budget, en payant même moins cher qu'à Paris, via
 
 Ce sera rebelote en 2011. Toujours 3 titres, avec les mêmes personnes aux
 manettes, et pour financer le tout
-([parce que faire de la musique, ça coûte de l'argent](http://www.youtube.com/watch?v=XKnCGUV8ZZI#t=0m30s]),
-le groupe a eu la bonne idée d'utiliser la plateforme de collecte de fonds [Kiss
-Kiss Bank
-Bank->http://www.kisskissbankbank.com/projects/enregistrement-du-premier-album-de-social-square)
+([parce que faire de la musique, ça coûte de l'argent](http://www.youtube.com/watch?v=XKnCGUV8ZZI#t=0m30s)),
+le groupe a eu la bonne idée d'utiliser la plateforme de collecte de fonds
+[Kiss Kiss Bank Bank](http://www.kisskissbankbank.com/projects/enregistrement-du-premier-album-de-social-square)
 où tout le monde pouvait participer à l'effort en contrepartie de lots sympas :
 
 - pour une participation de 5€, un exemplaire signé et numéroté de l'album
@@ -114,14 +113,14 @@ Pour que sa musique se fasse connaître, là aussi, il faut y consacrer du temps
 et envoyer les liens et les MP3 aux webzines et blogs musicaux. Il y a plus de
 chances de réussites de ce côté-là que vers la presse traditionnelle ou les
 radios. Au final, Social Square se retrouve avec de jolies chroniques sur le web
-chez [La Magic
-Box](http://90plan.ovh.net/~lamagicb/visuArticles.php3?typeArticle=9#4180],
+chez
+[La Magic Box](http://90plan.ovh.net/~lamagicb/visuArticles.php3?typeArticle=9#4180),
 [Addictif Zine](http://www.addictif-zine.com/accueil/item/2148-social-square-it-vs-you)
-ou [Indessence->http://indessence.net/2010/07/social-square-it-vs-you.html).
+ou [Indessence]http://indessence.net/2010/07/social-square-it-vs-you.html).
 
-Le petit plus sympa vient du blog des Inrocks [Gimme Indie
-Rock](http://blogs.lesinrocks.com/gimmeindierock/] qui a diffusé [ce petit
-strip->http://blogs.lesinrocks.com/gimmeindierock/2010/09/13/wonderflusocial-square/)
+Le petit plus sympa vient du blog des Inrocks
+[Gimme Indie Rock](http://blogs.lesinrocks.com/gimmeindierock/) qui a diffusé
+[ce petit strip](http://blogs.lesinrocks.com/gimmeindierock/2010/09/13/wonderflusocial-square/)
 et a permis à Social Square de faire copain-copain avec Wonderflu, l'autre cité
 du post (et dont l'écoute est également recommandée).
 

--- a/2011/2011-05-10-i-p-u-t-a-s-p-e-l-l-o-n-y-o-u.md
+++ b/2011/2011-05-10-i-p-u-t-a-s-p-e-l-l-o-n-y-o-u.md
@@ -71,16 +71,15 @@ comme ça qu'on va les aider à se remettre en question…
 
 ## Le plus dancefloor : _D.A.N.C.E._ de Justice
 
-Les Français qui ressemblent à Daft Punk, [qui sont peut-être le même
-groupe](http://flepi.net/image-insolite/daft-punk-et-justice-un-seul-et-meme-groupe-de-musique/]
+Les Français qui ressemblent à Daft Punk,
+[qui sont peut-être le même groupe](http://flepi.net/image-insolite/daft-punk-et-justice-un-seul-et-meme-groupe-de-musique/)
 mais
 [en fait non](http://www.facebook.com/pages/Non-Daft-punk-et-Justice-ne-sont-pas-le-m%C3%AAme-groupe/225096182451),
 avaient signé en 2007 ce tube incroyable : <strike>_Dance_</strike>
-_D.A.N.C.E._. Pendant ce temps-là, [Gala est toujours remplacée par un
-sosie->http://www.facebook.com/group.php?gid=97891375246], [c'est Rick Astley
-qui chante les titres de Kylie
-Minogue->http://www.youtube.com/watch?v=AVDogmtajKI], et [c'est toujours le
-vainqueur d'un concours de sosie qui se fait passer pour Paul
-McCartney->http://en.wikipedia.org/wiki/Paul_is_dead).
+_D.A.N.C.E._. Pendant ce temps-là,
+[Gala est toujours remplacée par un sosie](http://www.facebook.com/group.php?gid=97891375246),
+[c'est Rick Astley qui chante les titres de Kylie Minogue](http://www.youtube.com/watch?v=AVDogmtajKI),
+et
+[c'est toujours le vainqueur d'un concours de sosie qui se fait passer pour Paul McCartney](http://en.wikipedia.org/wiki/Paul_is_dead).
 
 {% youtube sy1dYFGkPUE %}

--- a/2011/2011-05-13-fun-friday-10.md
+++ b/2011/2011-05-13-fun-friday-10.md
@@ -18,9 +18,9 @@ tags:
 Les reconstitutions c'est bath. Que ce soit pour transformer des jeux vidéo, des
 dessins animés, des matches de foot, des films ou des algorithmes de tri.
 
-(voici d'ailleurs [un test de reconnaissance de pochettes en
-Lego](http://www.telegraph.co.uk/culture/culturepicturegalleries/8296237/Lego-album-covers-quiz.html?image=25]
-pour voir si vous avez bien travaillé [la dernière fois->801))
+(voici d'ailleurs
+[un test de reconnaissance de pochettes en Lego](http://www.telegraph.co.uk/culture/culturepicturegalleries/8296237/Lego-album-covers-quiz.html?image=25)
+pour voir si vous avez bien travaillé [la dernière fois](801))
 
 ## Olive & Tom en version humaine
 

--- a/2011/2011-05-17-cine-club-moi-j-vous-dis-06.md
+++ b/2011/2011-05-17-cine-club-moi-j-vous-dis-06.md
@@ -68,10 +68,10 @@ que le pauvre vieux, il fait ça en pensant leur faire plaisir.
 Ce film musical a été classé comme "culturally significant" aux États-Unis et
 figure régulièrement dans des listes des meilleurs films de l'histoire,
 notamment par le biais de ses nombreuses chansons, souvent interprétées par Judy
-Garland. Parmi ses titres : [*Meet Me in St.
-Louis*](http://www.youtube.com/watch?v=4JARDvdrAxk], _The Trolley Song_, _Have
-Yourself a Merry Little Christmas_ et [une chouette interprétation de _Skip to
-my Lou_->http://www.youtube.com/watch?v=jSY7jX28P48).
+Garland. Parmi ses titres :
+[_Meet Me in St. Louis_](http://www.youtube.com/watch?v=4JARDvdrAxk), _The
+Trolley Song_, _Have Yourself a Merry Little Christmas_ et
+[une chouette interprétation de _Skip to my Lou_](http://www.youtube.com/watch?v=jSY7jX28P48).
 
 Anecdote marrante, Judy Garland épousera Minnelli l'année suivante. Cette union
 donnera naissance à la Liza du même nom.

--- a/2011/2011-07-05-cine-club-moi-j-vous-dis-07.md
+++ b/2011/2011-07-05-cine-club-moi-j-vous-dis-07.md
@@ -31,11 +31,11 @@ Adam Belinski, qu'elle a déjà croisé à Londres.
 {% youtube ebEe8i-4aus %}
 
 Certes, le couple est séduisant (Jennifer Jones pétillante et pleine de charme
-comme une [Punky
-Brewster](http://www.dailymotion.com/video/x8tgu7_punky-brewster-generique-de-la-seri_creation]
+comme une
+[Punky Brewster](http://www.dailymotion.com/video/x8tgu7_punky-brewster-generique-de-la-seri_creation)
 devenue adulte, Charles Boyer - acteur français ! - à l'accent continental ayant
-certainement inspiré le personnage de [Jean
-Girard->http://www.dailymotion.com/video/x3z07e_talladega-nights-ricky-meets-jean-g_shortfilms)),
+certainement inspiré le personnage de
+[Jean Girard](http://www.dailymotion.com/video/x3z07e_talladega-nights-ricky-meets-jean-g_shortfilms)),
 certes on rit de bien des choses (surtout de la famille du pharmacien, sosie
 avant l'heure d'Alain Chabat), mais le film reste moins brillant que d'autres
 œuvres de Lubitsch telles que _Jeux Dangereux/To Be or Not to Be_ (comédie au
@@ -43,16 +43,16 @@ scénario génial sur l'invasion nazie en Pologne, remaké avec Mel Brooks en 19
 ou _Rendez-Vous/The Shop Around The Corner_ (une des toutes premières comédies
 romantiques de l'histoire).
 
-Notons malgré tout que Cluny Brown rejoint [Rusty James dans le clan de ceux
-qu'on appelle tout le temps par le prénom et le nom de famille](824] (la classe)
-et que [le film est disponible en intégralité à cette
-adresse->http://video.google.com/videoplay?docid=-4912689158924394462).
+Notons malgré tout que Cluny Brown rejoint
+[Rusty James dans le clan de ceux qu'on appelle tout le temps par le prénom et le nom de famille](824)
+(la classe) et que
+[le film est disponible en intégralité à cette adresse](http://video.google.com/videoplay?docid=-4912689158924394462).
 
-La musique qui va avec : rien de bien folichon sinon [cette scène où le sosie
-d'Alain Chabat joue du piano](http://youtu.be/i7NVoM9pv94?t=2m38s]. Du coup, ça
-donne envie de regarder _La Carioca_, mais pour ça il faut [cliquer
-ici->http://www.youtube.com/watch?v=HCdCMo9cd5k), car il y a toujours des gens
-pour bloquer l'intégration des vidéos sur les pages web. Les ringards !
+La musique qui va avec : rien de bien folichon sinon
+[cette scène où le sosie d'Alain Chabat joue du piano](http://youtu.be/i7NVoM9pv94?t=2m38s).
+Du coup, ça donne envie de regarder _La Carioca_, mais pour ça il faut
+[cliquer ici](http://www.youtube.com/watch?v=HCdCMo9cd5k), car il y a toujours
+des gens pour bloquer l'intégration des vidéos sur les pages web. Les ringards !
 
 ---
 
@@ -77,8 +77,8 @@ rentrer dans l'histoire, bizarrement structurée : une intrigue préliminaire qu
 dure presque la moitié du film, pas de réel enjeu sinon effectuer le travail du
 deuil. Néanmoins, on trouve sur le net quelques lectures intéressantes du film,
 que ce soit
-[ici](http://www.cineclubdecaen.com/realisat/moretti/chambredufils.htm] ou
-[là->http://www.cinetic.be/spip.php?article80).
+[ici](http://www.cineclubdecaen.com/realisat/moretti/chambredufils.htm) ou
+[là](http://www.cinetic.be/spip.php?article80).
 
 La musique qui va avec : _By This River_ de Brian Eno
 

--- a/2011/2011-08-01-reprise-hors-cadre.md
+++ b/2011/2011-08-01-reprise-hors-cadre.md
@@ -15,7 +15,7 @@ comments:
       Quand se décidera-t-on à pendre haut et court le créateur du vocodeur ?
 ---
 
-[Les Morning Benders ont décidé de massacrer le *Last Nite* des
-Strokes](http://youtu.be/HcaEM0GErQk]. On avait rarement vu pire depuis [la
-reprise de _Yesterday_ en reggae->http://www.youtube.com/watch?v=zoFzMrpS7nw).
+[Les Morning Benders ont décidé de massacrer le _Last Nite_ des Strokes](http://youtu.be/HcaEM0GErQk).
+On avait rarement vu pire depuis
+[la reprise de _Yesterday_ en reggae](http://www.youtube.com/watch?v=zoFzMrpS7nw).
 Le monde va mal !

--- a/2011/2011-08-15-submarine-richard-ayoade.md
+++ b/2011/2011-08-15-submarine-richard-ayoade.md
@@ -58,7 +58,7 @@ acoustique et mélancolique.
 En ce qui concerne le style du film, Ayoade avait dû répondre lors du dernier
 Sundance Film Festival aux nombreuses comparaisons qu’on faisait entre son film
 et ceux de Wes Anderson. Il y a pire comme comparaisons. Dans une interview pour
-[Gordon and the Whale](http://gordonandthewhale.com/] relayée par
+[Gordon and the Whale](http://gordonandthewhale.com/) relayée par
 [IndieWire)(http://blogs.indiewire.com/theplaylist/archives/submarine_director_richard_ayoade_responds_to_wes_anderson_comparisons/),
 loin de nier l’influence d’Anderson sur son film - et d’admettre que _Rushmore_
 est un film «complètement parfait» -, Ayoade avait surtout dressé une liste

--- a/2011/2011-08-15-submarine-richard-ayoade.md
+++ b/2011/2011-08-15-submarine-richard-ayoade.md
@@ -59,13 +59,12 @@ En ce qui concerne le style du film, Ayoade avait dû répondre lors du dernier
 Sundance Film Festival aux nombreuses comparaisons qu’on faisait entre son film
 et ceux de Wes Anderson. Il y a pire comme comparaisons. Dans une interview pour
 [Gordon and the Whale](http://gordonandthewhale.com/] relayée par
-[IndieWire](http://blogs.indiewire.com/theplaylist/archives/submarine_director_richard_ayoade_responds_to_wes_anderson_comparisons/),
+[IndieWire)(http://blogs.indiewire.com/theplaylist/archives/submarine_director_richard_ayoade_responds_to_wes_anderson_comparisons/),
 loin de nier l’influence d’Anderson sur son film - et d’admettre que _Rushmore_
 est un film «complètement parfait» -, Ayoade avait surtout dressé une liste
 d’autres influences plus secrètes mais selon lui tout aussi intéressantes. Voilà
-quelques items des influences, de quoi nourrir quelques futurs [ciné-club moi
-j’vous
-dis->http://www.deadrooster.org/spip.php?page=recherche&recherche=cin%C3%A9+club+dis)
+quelques items des influences, de quoi nourrir quelques futurs
+[ciné-club moi j’vous dis](http://www.deadrooster.org/spip.php?page=recherche&recherche=cin%C3%A9+club+dis)
 : -* [*The Ice Storm*](http://www.imdb.com/title/tt0119349/), d’Ang Lee
 (1997) -* [_Flirting_](http://www.imdb.com/title/tt0101898/), de John Duigan
 (1991) -* [*Show Me Love*](http://www.imdb.com/title/tt0150662/), de Lukas
@@ -82,13 +81,13 @@ d’écolier complètement intemporels qui participent à rendre le film diffici
 dater (les looks et les décos laissent penser que l’action se passe dans les 70s
 mais _Crocodile Dundee_, sorti en 1986, est mentionné). Je vous recommande
 d’ailleurs ce
-[post](http://redingote.fr/breves/les-costumes-des-films-de-wes-anderson/] sur
+[post](http://redingote.fr/breves/les-costumes-des-films-de-wes-anderson/) sur
 les costumes des films de Wes Anderson par le site
-[Redingote->http://redingote.fr/).
+[Redingote](http://redingote.fr/).
 
 Finissons en vrac : -\* _White Noise_, de Don DeLillo, est le livre préféré de
 Joe Dunthorne (source
 [ici](http://www.independent.co.uk/arts-entertainment/books/features/one-minute-with-joe-dunthorne-novelist-2331732.html))
--\* Wes Anderson fait tailler ses costards chez [Mr. Ned](http://mrnednyc.com/],
+-\* Wes Anderson fait tailler ses costards chez [Mr. Ned](http://mrnednyc.com/),
 à New York (source
-[ici->http://www.nytimes.com/2004/09/19/style/tmagazine/MAN12))
+[ici](http://www.nytimes.com/2004/09/19/style/tmagazine/MAN12))

--- a/2011/2011-08-15-submarine-richard-ayoade.md
+++ b/2011/2011-08-15-submarine-richard-ayoade.md
@@ -59,7 +59,7 @@ En ce qui concerne le style du film, Ayoade avait dû répondre lors du dernier
 Sundance Film Festival aux nombreuses comparaisons qu’on faisait entre son film
 et ceux de Wes Anderson. Il y a pire comme comparaisons. Dans une interview pour
 [Gordon and the Whale](http://gordonandthewhale.com/) relayée par
-[IndieWire)(http://blogs.indiewire.com/theplaylist/archives/submarine_director_richard_ayoade_responds_to_wes_anderson_comparisons/),
+[IndieWire](http://blogs.indiewire.com/theplaylist/archives/submarine_director_richard_ayoade_responds_to_wes_anderson_comparisons/),
 loin de nier l’influence d’Anderson sur son film - et d’admettre que _Rushmore_
 est un film «complètement parfait» -, Ayoade avait surtout dressé une liste
 d’autres influences plus secrètes mais selon lui tout aussi intéressantes. Voilà

--- a/2011/2011-08-20-yes.md
+++ b/2011/2011-08-20-yes.md
@@ -21,10 +21,10 @@ l'atteste par exemple cette
 [image](http://www.notrealnews.co.uk/wp-content/uploads/2011/05/yes-band1.jpg).
 
 Non, là où le bât blesse, c'est visuellement et musicalement quoi. Déjà, on n'a
-pas idée de jouer sur [cette
-guitare](http://images4.wikia.nocookie.net/__cb20091112203260/uncyclopedia/images/c/c0/Squire_Weapon.jpg]
+pas idée de jouer sur
+[cette guitare](http://images4.wikia.nocookie.net/__cb20091112203260/uncyclopedia/images/c/c0/Squire_Weapon.jpg)
 hein ! Et ce
-[logo->http://www.livemusicnewsandreview.com/Content/NetSite_1109/_groups/505/pages/YesLogoFullCircle1.jpg)
+[logo](http://www.livemusicnewsandreview.com/Content/NetSite_1109/_groups/505/pages/YesLogoFullCircle1.jpg)
 ? On dirait un mauvais logo de TF1 des eighties mélangé avec celui d'Antenne 2
 d'avant celui avec la pomme…
 

--- a/2011/2011-08-24-the-graduate-mike-nichols.md
+++ b/2011/2011-08-24-the-graduate-mike-nichols.md
@@ -25,15 +25,15 @@ tags:
 
 Benjamin Braddock vient d'être diplômé. Ses parents et leurs amis sont tous très
 contents et s'interrogent maintenant sur la suite : "tu es si brillant Benjamin,
-que veux-tu faire maintenant ? [Du plastique
-?](http://www.youtube.com/watch?v=PSxihhBzCjk]". Le problème de Benjamin, c'est
-qu'il n'en a aucune idée. Parmi les convives de la fête qui lui est consacrée se
-trouve Mrs. Robinson, la femme d'un ami proche de Papa Braddock, alcoolique et
-[cougar->http://fr.wikipedia.org/wiki/Cougar_(femme)) dans son temps-libre.
-Benjamin se laisse séduire par les avances de la dame et se met à glander
-sévère, au grand dam de ses parents qui, ne sachant rien de la relation liant
-leur fils et leur amie, insistent pour qu'il rencontre la fille de celle-ci,
-Elaine.
+que veux-tu faire maintenant ?
+[Du plastique ?](http://www.youtube.com/watch?v=PSxihhBzCjk)". Le problème de
+Benjamin, c'est qu'il n'en a aucune idée. Parmi les convives de la fête qui lui
+est consacrée se trouve Mrs. Robinson, la femme d'un ami proche de Papa
+Braddock, alcoolique et [cougar](<http://fr.wikipedia.org/wiki/Cougar_(femme)>)
+dans son temps-libre. Benjamin se laisse séduire par les avances de la dame et
+se met à glander sévère, au grand dam de ses parents qui, ne sachant rien de la
+relation liant leur fils et leur amie, insistent pour qu'il rencontre la fille
+de celle-ci, Elaine.
 
 {% youtube -3lKbMBab18 %}
 
@@ -79,9 +79,9 @@ cœur car on est devenus très copains avec Benjamin. Sur toute la durée du fil
 _Le Lauréat_ séduit par sa bande-son, signée Simon & Garfunkel.
 
 La B.O. du film détrônera d'ailleurs le _White Album_ des Beatles du sommet des
-charts, porté par les trois titres devenus depuis des standards [*Mrs.
-Robinson*](http://www.youtube.com/watch?v=mDrTCqXZrTQ], [*The Sound of
-Silence*->http://www.youtube.com/watch?v=eZGWQauQOAQ] et [_Scarborough
+charts, porté par les trois titres devenus depuis des standards
+[_Mrs. Robinson_](http://www.youtube.com/watch?v=mDrTCqXZrTQ), [*The Sound of
+Silence*](http://www.youtube.com/watch?v=eZGWQauQOAQ] et [_Scarborough
 Fair_->http://www.youtube.com/watch?v=nWu6ney5hYQ).
 
 **{La suite ?**}

--- a/2011/2011-08-24-the-graduate-mike-nichols.md
+++ b/2011/2011-08-24-the-graduate-mike-nichols.md
@@ -80,9 +80,9 @@ _Le Lauréat_ séduit par sa bande-son, signée Simon & Garfunkel.
 
 La B.O. du film détrônera d'ailleurs le _White Album_ des Beatles du sommet des
 charts, porté par les trois titres devenus depuis des standards
-[_Mrs. Robinson_](http://www.youtube.com/watch?v=mDrTCqXZrTQ), [*The Sound of
-Silence*](http://www.youtube.com/watch?v=eZGWQauQOAQ) et [_Scarborough
-Fair_->http://www.youtube.com/watch?v=nWu6ney5hYQ).
+[_Mrs. Robinson_](http://www.youtube.com/watch?v=mDrTCqXZrTQ),
+[_The Sound of Silence_](http://www.youtube.com/watch?v=eZGWQauQOAQ) et
+[_Scarborough Fair_](http://www.youtube.com/watch?v=nWu6ney5hYQ).
 
 **{La suite ?**}
 

--- a/2011/2011-08-24-the-graduate-mike-nichols.md
+++ b/2011/2011-08-24-the-graduate-mike-nichols.md
@@ -81,7 +81,7 @@ _Le Lauréat_ séduit par sa bande-son, signée Simon & Garfunkel.
 La B.O. du film détrônera d'ailleurs le _White Album_ des Beatles du sommet des
 charts, porté par les trois titres devenus depuis des standards
 [_Mrs. Robinson_](http://www.youtube.com/watch?v=mDrTCqXZrTQ), [*The Sound of
-Silence*](http://www.youtube.com/watch?v=eZGWQauQOAQ] et [_Scarborough
+Silence*](http://www.youtube.com/watch?v=eZGWQauQOAQ) et [_Scarborough
 Fair_->http://www.youtube.com/watch?v=nWu6ney5hYQ).
 
 **{La suite ?**}

--- a/2011/2011-09-04-jamais-dire-jamais.md
+++ b/2011/2011-09-04-jamais-dire-jamais.md
@@ -9,6 +9,6 @@ date: 2011-09-04 21:50:02 +0200
 ---
 
 Carla Bruni-Sarkozy semble n'avoir
-[__jamais__](http://www.lemonde.fr/politique/article/2011/09/04/carla-bruni-sarkozy-je-ne-montrerai-jamais-de-photos-de-mon-enfant_1567613_823448.html]
-regardé [Fievel->http://www.youtube.com/watch?v=mg1Zpjme9Bc) avec son fils aîné.
+[**jamais**](http://www.lemonde.fr/politique/article/2011/09/04/carla-bruni-sarkozy-je-ne-montrerai-jamais-de-photos-de-mon-enfant_1567613_823448.html)
+regardé [Fievel](http://www.youtube.com/watch?v=mg1Zpjme9Bc) avec son fils aîné.
 Le monde va mal !

--- a/2011/2011-09-07-le-bien-et-le-mal.md
+++ b/2011/2011-09-07-le-bien-et-le-mal.md
@@ -10,7 +10,7 @@ date: 2011-09-07 21:00:07 +0200
 
 [Hanson critique l'attitude des Kings of
 Leon](http://www.nme.com/news/kings-of-leon/58619).
-[Anne)(http://fr.wikipedia.org/wiki/Anne_Meson), elle, s'était bien gardée de
+[Anne](http://fr.wikipedia.org/wiki/Anne_Meson), elle, s'était bien gardée de
 critiquer
 [Mallaury Nataf](http://fr.wikipedia.org/wiki/Mallaury_Nataf#Pol.C3.A9mique_autour_de_sa_prestation_au_Jacky_Show).
 Mmmbop, les temps changent. Le monde va mal !

--- a/2011/2011-09-07-le-bien-et-le-mal.md
+++ b/2011/2011-09-07-le-bien-et-le-mal.md
@@ -10,7 +10,7 @@ date: 2011-09-07 21:00:07 +0200
 
 [Hanson critique l'attitude des Kings of
 Leon](http://www.nme.com/news/kings-of-leon/58619].
-[Anne](http://fr.wikipedia.org/wiki/Anne_Meson), elle, s'était bien gardée de
-critiquer [Mallaury
-Nataf->http://fr.wikipedia.org/wiki/Mallaury_Nataf#Pol.C3.A9mique_autour_de_sa_prestation_au_Jacky_Show).
+[Anne)(http://fr.wikipedia.org/wiki/Anne_Meson), elle, s'était bien gardée de
+critiquer
+[Mallaury Nataf](http://fr.wikipedia.org/wiki/Mallaury_Nataf#Pol.C3.A9mique_autour_de_sa_prestation_au_Jacky_Show).
 Mmmbop, les temps changent. Le monde va mal !

--- a/2011/2011-09-07-le-bien-et-le-mal.md
+++ b/2011/2011-09-07-le-bien-et-le-mal.md
@@ -9,7 +9,7 @@ date: 2011-09-07 21:00:07 +0200
 ---
 
 [Hanson critique l'attitude des Kings of
-Leon](http://www.nme.com/news/kings-of-leon/58619].
+Leon](http://www.nme.com/news/kings-of-leon/58619).
 [Anne)(http://fr.wikipedia.org/wiki/Anne_Meson), elle, s'était bien gardée de
 critiquer
 [Mallaury Nataf](http://fr.wikipedia.org/wiki/Mallaury_Nataf#Pol.C3.A9mique_autour_de_sa_prestation_au_Jacky_Show).

--- a/2011/2011-09-07-le-bien-et-le-mal.md
+++ b/2011/2011-09-07-le-bien-et-le-mal.md
@@ -8,8 +8,7 @@ cover: homer-simpson-evil-angel.jpg
 date: 2011-09-07 21:00:07 +0200
 ---
 
-[Hanson critique l'attitude des Kings of
-Leon](http://www.nme.com/news/kings-of-leon/58619).
+[Hanson critique l'attitude des Kings of Leon](http://www.nme.com/news/kings-of-leon/58619).
 [Anne](http://fr.wikipedia.org/wiki/Anne_Meson), elle, s'était bien gardée de
 critiquer
 [Mallaury Nataf](http://fr.wikipedia.org/wiki/Mallaury_Nataf#Pol.C3.A9mique_autour_de_sa_prestation_au_Jacky_Show).

--- a/2011/2011-09-08-bored-to-death.md
+++ b/2011/2011-09-08-bored-to-death.md
@@ -46,14 +46,13 @@ névroses enfantines et ses mésaventures diverses, notamment sexuelles. Le sexe
 semble d'ailleurs beaucoup intéresser Ames. Même s'il est cantonné à l'arrière
 plan dans la série, le personnage de Super-Ray ne peut pas être né dans l'esprit
 de quelqu'un qui se désintéresse de la chose. L'intérêt d'Ames semble donc même
-se consacrer principalement au zizi puisqu'il est à l'origine du [concours du
-bâtiment le plus
-phallique](http://en.wikipedia.org/wiki/Most_Phallic_Building_contest] (vous
-serez ravis d'apprendre que le vainqueur est [un château d'eau du
-Michigan->http://en.wikipedia.org/wiki/Ypsilanti_Water_Tower) surnommée "the
-brick dick" par les habitants du coin). Pour conclure sur la chose, Ames fait
-une apparition dans la saison 2 de la série et vous ne serez plus surpris
-d'apprendre qu'il y figure… les fesses à l'air, bien entendu.
+se consacrer principalement au zizi puisqu'il est à l'origine du
+[concours du bâtiment le plus phallique](http://en.wikipedia.org/wiki/Most_Phallic_Building_contest)
+(vous serez ravis d'apprendre que le vainqueur est
+[un château d'eau du Michigan](http://en.wikipedia.org/wiki/Ypsilanti_Water_Tower)
+surnommée "the brick dick" par les habitants du coin). Pour conclure sur la
+chose, Ames fait une apparition dans la saison 2 de la série et vous ne serez
+plus surpris d'apprendre qu'il y figure… les fesses à l'air, bien entendu.
 
 Mais ne vous y trompez pas, la série s'articule autour de noeuds situés
 au-dessus de la ceinture. En gros, chaque épisode est centré sur la résolution

--- a/2011/2011-09-16-fun-friday-11.md
+++ b/2011/2011-09-16-fun-friday-11.md
@@ -31,10 +31,10 @@ comments:
 
 ## J'ai besoin d'un sanglier
 
-Gérard Depardieu, visiblement en tournage de la [4ème adaptation ciné
-d'Astérix](http://www.allocine.fr/film/fichefilm_gen_cfilm=177895.html], arrive
-à mettre en scène [ses récents faits
-divers->http://lci.tf1.fr/people/gerard-depardieu-urine-dans-un-avion-6642138.html)
+Gérard Depardieu, visiblement en tournage de la
+[4ème adaptation ciné d'Astérix](http://www.allocine.fr/film/fichefilm_gen_cfilm=177895.html),
+arrive à mettre en scène
+[ses récents faits divers](http://lci.tf1.fr/people/gerard-depardieu-urine-dans-un-avion-6642138.html)
 de manière fun.
 
 {% youtube L7estuFU6VU %}
@@ -101,9 +101,8 @@ que j'arrête de boire. (Graham Coxon)</quote>
 Il y a même
 [un tee-shirt](http://popchartlab.tumblr.com/post/4346725536/rock-out-with-our-visual-compendium-of-notable).
 
-Et les mêmes mecs vont encore plus loin que ce qu'on racontait [là](777] avec
-[cet autre
-graphique->http://popchartlab.tumblr.com/post/4212389296/games-played-in-the-1980s).
+Et les mêmes mecs vont encore plus loin que ce qu'on racontait [là](777) avec
+[cet autre graphique](http://popchartlab.tumblr.com/post/4212389296/games-played-in-the-1980s).
 
 ## Dear blank, please blank
 

--- a/2011/2011-09-28-eulogie-pour-r-e-m.md
+++ b/2011/2011-09-28-eulogie-pour-r-e-m.md
@@ -42,7 +42,7 @@ Clavier, il est nécessaire de se souvenir qu'avant d'être ce qu'ils sont deven
 [embarrassants](http://youtu.be/QEKh_BCe190)), ils étaient d'un tout autre
 tonneau dans leurs beaux jours
 ([inspirés](http://www.youtube.com/watch?v=-be65CIwE08) et
-[géniaux->http://www.youtube.com/watch?v=4eEfDIRaR4c)). Comme disait Chamfort,
+[géniaux](http://www.youtube.com/watch?v=4eEfDIRaR4c)). Comme disait Chamfort,
 «Quiconque a détruit un préjugé, un seul préjugé, est un bienfaiteur du genre
 humain». Alors merci de bien vouloir vous souvenir que ces chansons sont de
 bonnes chansons pour que je puisse mettre ça sur mon CV.

--- a/2011/2011-09-28-eulogie-pour-r-e-m.md
+++ b/2011/2011-09-28-eulogie-pour-r-e-m.md
@@ -36,12 +36,12 @@ aujourd'hui.
 
 Déjà, il y a les tubes monstrueux du groupe : _Losing My Religion_, _Shiny Happy
 People_ et _Everybody Hurts_. Toutes ces chansons souffrent bien sûr du
-[syndrome de La Folie des Grandeurs](266], mais tels Les Inconnus ou Christian
+[syndrome de La Folie des Grandeurs](266), mais tels Les Inconnus ou Christian
 Clavier, il est nécessaire de se souvenir qu'avant d'être ce qu'ils sont devenus
 ([insipides](http://youtu.be/-qelka0YcsY) et
 [embarrassants)(http://youtu.be/QEKh_BCe190)), ils étaient d'un tout autre
 tonneau dans leurs beaux jours
-([inspirés](http://www.youtube.com/watch?v=-be65CIwE08] et
+([inspirés](http://www.youtube.com/watch?v=-be65CIwE08) et
 [géniaux->http://www.youtube.com/watch?v=4eEfDIRaR4c)). Comme disait Chamfort,
 «Quiconque a détruit un préjugé, un seul préjugé, est un bienfaiteur du genre
 humain». Alors merci de bien vouloir vous souvenir que ces chansons sont de

--- a/2011/2011-09-28-eulogie-pour-r-e-m.md
+++ b/2011/2011-09-28-eulogie-pour-r-e-m.md
@@ -39,9 +39,9 @@ People_ et _Everybody Hurts_. Toutes ces chansons souffrent bien sûr du
 [syndrome de La Folie des Grandeurs](266], mais tels Les Inconnus ou Christian
 Clavier, il est nécessaire de se souvenir qu'avant d'être ce qu'ils sont devenus
 ([insipides](http://youtu.be/-qelka0YcsY) et
-[embarrassants](http://youtu.be/QEKh_BCe190)), ils étaient d'un tout autre
+[embarrassants)(http://youtu.be/QEKh_BCe190)), ils étaient d'un tout autre
 tonneau dans leurs beaux jours
-([inspirés->http://www.youtube.com/watch?v=-be65CIwE08] et
+([inspirés](http://www.youtube.com/watch?v=-be65CIwE08] et
 [géniaux->http://www.youtube.com/watch?v=4eEfDIRaR4c)). Comme disait Chamfort,
 «Quiconque a détruit un préjugé, un seul préjugé, est un bienfaiteur du genre
 humain». Alors merci de bien vouloir vous souvenir que ces chansons sont de
@@ -64,9 +64,9 @@ l'image d'une pochette et des pop-ups partout suffit, à mon humble avis :
 
 Quant à _Everybody Hurts_, j'ai changé d'avis. En fait, elle est vraiment un peu
 chiante mais ceux qui veulent rester dans les bouchons pendant plus de 5 minutes
-peuvent [cliquer ici](http://youtu.be/ijZRCIrTgQc] pour en voir le clip et ceux
+peuvent [cliquer ici](http://youtu.be/ijZRCIrTgQc) pour en voir le clip et ceux
 qui veulent juste voir la dernière minute, vraiment plus cool que le reste,
-préféreront [cliquer là->http://youtu.be/ijZRCIrTgQc?t=4m9s).
+préféreront [cliquer là](http://youtu.be/ijZRCIrTgQc?t=4m9s).
 
 Derrière ces trois monstres, d'autres beaux morceaux se cachent et en voici les
 deux meilleurs représentants à mes yeux, que je vous invite à écouter aussi

--- a/2011/2011-09-28-eulogie-pour-r-e-m.md
+++ b/2011/2011-09-28-eulogie-pour-r-e-m.md
@@ -39,7 +39,7 @@ People_ et _Everybody Hurts_. Toutes ces chansons souffrent bien sûr du
 [syndrome de La Folie des Grandeurs](266), mais tels Les Inconnus ou Christian
 Clavier, il est nécessaire de se souvenir qu'avant d'être ce qu'ils sont devenus
 ([insipides](http://youtu.be/-qelka0YcsY) et
-[embarrassants)(http://youtu.be/QEKh_BCe190)), ils étaient d'un tout autre
+[embarrassants](http://youtu.be/QEKh_BCe190)), ils étaient d'un tout autre
 tonneau dans leurs beaux jours
 ([inspirés](http://www.youtube.com/watch?v=-be65CIwE08) et
 [géniaux->http://www.youtube.com/watch?v=4eEfDIRaR4c)). Comme disait Chamfort,

--- a/2011/2011-09-30-fun-friday-12.md
+++ b/2011/2011-09-30-fun-friday-12.md
@@ -24,7 +24,7 @@ le véritable nom de ce qu'on appelle plus communément "la boule de merde du
 nombril". On y apprend que sa création reste un mystère mais que ce phénomène
 touche environ une personne sur deux.
 
-En vous rendant sur [ce site web](http://www.abc.net.au/science/k2/lint/], vous
+En vous rendant sur [ce site web](http://www.abc.net.au/science/k2/lint/), vous
 apprendrez également que plus on vieillit, plus on crée des peluches ombilicales
 et que les hommes sont plus touchés que les femmes. Comment sait-on tout ça ?
 Grâce à un sondage de Dr. Karl, qui lui a valu de remporter un Ig-Nobel Prize

--- a/2011/2011-09-30-fun-friday-12.md
+++ b/2011/2011-09-30-fun-friday-12.md
@@ -28,10 +28,10 @@ En vous rendant sur [ce site web](http://www.abc.net.au/science/k2/lint/], vous
 apprendrez également que plus on vieillit, plus on crée des peluches ombilicales
 et que les hommes sont plus touchés que les femmes. Comment sait-on tout ça ?
 Grâce à un sondage de Dr. Karl, qui lui a valu de remporter un Ig-Nobel Prize
-en 2002. Il y a aussi [ce site](http://www.feargod.net/fluff.html) d'un mec qui
-collectionne les peluches ombilicales ou [cette
-page->http://www.craftbits.com/project/bellybutton-lint-collecters) qui vous
-explique comment fabriquer un ramasseur de peluche ombilicale maison.
+en 2002. Il y a aussi [ce site)(http://www.feargod.net/fluff.html) d'un mec qui
+collectionne les peluches ombilicales ou
+[cette page](http://www.craftbits.com/project/bellybutton-lint-collecters) qui
+vous explique comment fabriquer un ramasseur de peluche ombilicale maison.
 
 ## Une illusion optique
 
@@ -44,8 +44,8 @@ Admettez que vos yeux vous manipulent
 
 À quoi ressembleraient Barack Obama, Justin Bieber, Jennifer Lopez, Katie Perry
 ou Natalie Portman s'ils n'avaient pas de sourcils ? Réponse
-[ici](http://www.mymodernmet.com/profiles/blogs/celebs-with-no-eyebrows].
-Retrouvez l'intégrale [là->http://celebswithnoeyebrows.com/).
+[ici](http://www.mymodernmet.com/profiles/blogs/celebs-with-no-eyebrows).
+Retrouvez l'intégrale [là](http://celebswithnoeyebrows.com/).
 
 ## L'humour des porteurs d'eau
 
@@ -59,6 +59,6 @@ Cavaliers de Cleveland. Stacey King y avait marqué 1 point donc. Il est marrant
 
 ## Conseils informatiques en BD
 
-De l'humour geek pour finir : [The Oatmeal](http://theoatmeal.com/] donne, en
-BD, [une leçon de design aux créateurs de sites web pour que leur système
-d'achat en ligne soit moins nul->http://theoatmeal.com/comics/shopping_cart).
+De l'humour geek pour finir : [The Oatmeal](http://theoatmeal.com/) donne, en
+BD,
+[une leçon de design aux créateurs de sites web pour que leur système d'achat en ligne soit moins nul](http://theoatmeal.com/comics/shopping_cart).

--- a/2011/2011-09-30-fun-friday-12.md
+++ b/2011/2011-09-30-fun-friday-12.md
@@ -28,7 +28,7 @@ En vous rendant sur [ce site web](http://www.abc.net.au/science/k2/lint/), vous
 apprendrez également que plus on vieillit, plus on crée des peluches ombilicales
 et que les hommes sont plus touchés que les femmes. Comment sait-on tout ça ?
 Grâce à un sondage de Dr. Karl, qui lui a valu de remporter un Ig-Nobel Prize
-en 2002. Il y a aussi [ce site)(http://www.feargod.net/fluff.html) d'un mec qui
+en 2002. Il y a aussi [ce site](http://www.feargod.net/fluff.html) d'un mec qui
 collectionne les peluches ombilicales ou
 [cette page](http://www.craftbits.com/project/bellybutton-lint-collecters) qui
 vous explique comment fabriquer un ramasseur de peluche ombilicale maison.

--- a/2011/2011-10-03-salut-les-copains-de-facebook.md
+++ b/2011/2011-10-03-salut-les-copains-de-facebook.md
@@ -8,8 +8,7 @@ cover: photo-de-classe-vintage.jpg
 date: 2011-10-03 00:14:13 +0200
 ---
 
-[Mick Jagger a déclaré : "Je passe trop de temps sur
-Facebook".](http://www.nme.com/news/the-rolling-stones/59542] Pendant ce
-temps-là, on parle de [Gérard Lenormand sur Copains
-d'Avant->http://copainsdavant.linternaute.com/temoignage/temoignage/397089/vacances-avec-gerard-lenormand/)
+[Mick Jagger a déclaré : "Je passe trop de temps sur Facebook".](http://www.nme.com/news/the-rolling-stones/59542)
+Pendant ce temps-là, on parle de
+[Gérard Lenormand sur Copains d'Avant](http://copainsdavant.linternaute.com/temoignage/temoignage/397089/vacances-avec-gerard-lenormand/)
 mais on n'a toujours pas de page officielle. Le monde va mal !

--- a/2011/2011-10-05-les-hooray-henrys-encore-spolies.md
+++ b/2011/2011-10-05-les-hooray-henrys-encore-spolies.md
@@ -12,6 +12,6 @@ tags:
   - Queen
 ---
 
-Selon des scientifiques, _We Are The Champions_, de Queen, [serait la chanson la
-plus catchy de tous les temps](http://www.nme.com/news/queen/59530]. Et
-[_Girl_->248) des Hooray Henrys alors ? Le monde va mal !
+Selon des scientifiques, _We Are The Champions_, de Queen,
+[serait la chanson la plus catchy de tous les temps](http://www.nme.com/news/queen/59530).
+Et [_Girl_](248) des Hooray Henrys alors ? Le monde va mal !

--- a/2011/2011-10-13-merites-non-reconnus.md
+++ b/2011/2011-10-13-merites-non-reconnus.md
@@ -8,8 +8,8 @@ cover: david-et-jonathan.jpg
 date: 2011-10-13 22:53:14 +0200
 ---
 
-Le verdict est tombé : We Build This City, de Starship a été [élue pire chanson
-des années 80](http://www.nme.com/news/various-artists/59655]. David et Jonathan
-vont faire la gueule : ils avaient pourtant [tout
-donné->http://www.youtube.com/watch?v=uzP7AE08EpU). C'est dégueulasse ! Le monde
-va mal !
+Le verdict est tombé : We Build This City, de Starship a été
+[élue pire chanson des années 80](http://www.nme.com/news/various-artists/59655).
+David et Jonathan vont faire la gueule : ils avaient pourtant
+[tout donné](http://www.youtube.com/watch?v=uzP7AE08EpU). C'est dégueulasse ! Le
+monde va mal !

--- a/2011/2011-10-14-moneyball-bennett-miller.md
+++ b/2011/2011-10-14-moneyball-bennett-miller.md
@@ -43,19 +43,19 @@ Jonah Hill et lancer la saison des Athletics. La construction du film est très
 linéaire, basée sur le déroulement de la saison où se greffe une relation
 père-fille. Il séduit inévitablement même si on ne connaît que peu de choses au
 baseball. Cadeau pour les Français, on peut même regarder le film en se mettant
-en tête que finalement, Brad Pitt joue un peu [le rôle de Guy
-Roux](http://www.lemeilleurdupsg.com/images/news/image/Autres/Guy_Roux.jpg],
+en tête que finalement, Brad Pitt joue un peu
+[le rôle de Guy Roux](http://www.lemeilleurdupsg.com/images/news/image/Autres/Guy_Roux.jpg),
 chose cocasse s'il en est. La version française sort le 16 novembre, s'appelle
-_Le Stratège_ ([encore->http://www.deadrooster.org/Suceur-de-pouce-difficile-et)
+_Le Stratège_ ([encore](http://www.deadrooster.org/Suceur-de-pouce-difficile-et)
 une bonne idée non ?) et maintenant que j'habite à Boston, je ne me priverai pas
 de me la péter en parlant des films avant leur sortie en France.
 
 Côté bande-son, on est aussi assez gâté. La bande originale est signée Mychael
-Danna (le même que pour _Little Miss Sunshine_), la version light de [*The
-Show*](http://www.youtube.com/watch?v=elsh3J5lJ6g&ob=av2e] que joue la fille de
-Billy est bizarrement assez charmante et on a le droit aux Black Keys avec
-[_Howlin' For You_->http://www.youtube.com/watch?v=TLSpj7q6_mM), dont il existe
-un clip très marrant :
+Danna (le même que pour _Little Miss Sunshine_), la version light de
+[_The Show_](http://www.youtube.com/watch?v=elsh3J5lJ6g&ob=av2e) que joue la
+fille de Billy est bizarrement assez charmante et on a le droit aux Black Keys
+avec [_Howlin' For You_](http://www.youtube.com/watch?v=TLSpj7q6_mM), dont il
+existe un clip très marrant :
 
 {% youtube TLSpj7q6_mM %}
 

--- a/2011/2011-10-25-dum-dum-girls-only-in-dreams.md
+++ b/2011/2011-10-25-dum-dum-girls-only-in-dreams.md
@@ -36,33 +36,32 @@ désagréable, mais derrière, pas grand chose. Les Inrocks avaient écrit
 [ici](http://www.lesinrocks.com/musique/musique-article/t/49359/date/2010-08-16/article/on-y-est-la-route-du-rock-jour-3/]
 la déception («les petits rollercoasters malins de l’album sont ici enchaînés
 sans grande vie, semblent presque interchangeables, les morceaux semblent cloués
-au sol») et se moquaient même d'un
-[camel toe](http://fr.wikipedia.org/wiki/Cameltoe), les fripons. On n'était pas
-loin de tirer un trait sur les Dum Dum Girls : sans doute un groupe opportuniste
-se lançant dans la brèche créée par [Best Coast->657), et qu'on aurait vite
-oublié.
+au sol») et se moquaient même d'un [camel
+toe)(http://fr.wikipedia.org/wiki/Cameltoe), les fripons. On n'était pas loin de
+tirer un trait sur les Dum Dum Girls : sans doute un groupe opportuniste se
+lançant dans la brèche créée par [Best Coast](657), et qu'on aurait vite oublié.
 
 <img491>
 
 Sauf qu'il y a quelques semaines, le groupe a sorti son second album, _Only In
 Dreams_. Si les morceaux d'ouverture sont aussi immédiatement séduisants et
 laissent penser qu'on va avoir un dispensable copier-coller du premier opus
-(_Always Looking_, [_Bedroom Eyes_](918]), les titres suivants rendent
+(_Always Looking_, [_Bedroom Eyes_](918)), les titres suivants rendent
 l'ensemble plus subtil, donnent de l'épaisseur aux Dum Dum Girls qui se montrent
 bien plus ambitieuses et appliquées qu'on n'auraient pu le croire. Le morceau le
 plus bluffant est bien sûr _Coming Down_, chef d'oeuvre mélancolique au tempo
-d'une lenteur inédite pour le groupe (et que vous pouvez écouter sur [le premier
-épisode du podcast Dead Rooster->924)). Le titre équilibre l'album, sans trahir
-ses voisins et donne envie de réécouter l'ensemble, encore et encore. On se rend
-alors compte d'une variété de tons dont on n'aurait jamais soupçonner le groupe
-capable (_In My Head_ ou _Hold Your Hand_).
+d'une lenteur inédite pour le groupe (et que vous pouvez écouter sur
+[le premier épisode du podcast Dead Rooster](924)). Le titre équilibre l'album,
+sans trahir ses voisins et donne envie de réécouter l'ensemble, encore et
+encore. On se rend alors compte d'une variété de tons dont on n'aurait jamais
+soupçonner le groupe capable (_In My Head_ ou _Hold Your Hand_).
 
 <img492>
 
 Derrière les Dum Dum Girls, il serait difficile de parler de groupe. Il s'agit
 plutôt de Dee Dee
-(ex-[Grand Ole Party](http://www.youtube.com/watch?v=Xziod5qt03k]) et [des
-Ringo-ettes->277]. Il a donc bien fallu que Dee Dee s'entoure d'un bon
+(ex-[Grand Ole Party](http://www.youtube.com/watch?v=Xziod5qt03k)) et [des
+Ringo-ettes](277]. Il a donc bien fallu que Dee Dee s'entoure d'un bon
 producteur aux manettes de l'album. Elle en a même pris deux. Le premier
 s'appelle Richard Gottehrer, qui n'a jamais écrit [*Le
 Youki*->http://www.youtube.com/watch?v=Wx7vKvQ4axQ] ou [*Poil Au
@@ -75,8 +74,8 @@ photo->http://en.wikipedia.org/wiki/File:Sune_Rose_Wagner_-_The_Raveonettes_-_Ro
 dans la production des Dum Dum.
 
 Pour conclure, pourquoi "Dum Dum Girls" ? À cause de
-[ça](http://en.wikipedia.org/wiki/Dum-Dum_(album)] et de
-[ça->http://youtu.be/-ioRWlG9PBQ).
+[ça](<http://en.wikipedia.org/wiki/Dum-Dum_(album)>) et de
+[ça](http://youtu.be/-ioRWlG9PBQ).
 
 PS : en écrivant ce post, je suis donc tombé sur ce passage dans la critique des
 Inrocks susmentionnée : «contre toute logique physique, le groupe prend un peu

--- a/2011/2011-10-25-dum-dum-girls-only-in-dreams.md
+++ b/2011/2011-10-25-dum-dum-girls-only-in-dreams.md
@@ -33,7 +33,7 @@ La tournée française, elle, avait déçu. Conforme à ce qu'en disait la press
 prestation à la Route du Rock 2010 fut loin des sommets historiques du festival
 : la pose bas-résille-et-Ray-Ban des quatre filles du groupe n'est certes pas
 désagréable, mais derrière, pas grand chose. Les Inrocks avaient écrit
-[ici](http://www.lesinrocks.com/musique/musique-article/t/49359/date/2010-08-16/article/on-y-est-la-route-du-rock-jour-3/]
+[ici](http://www.lesinrocks.com/musique/musique-article/t/49359/date/2010-08-16/article/on-y-est-la-route-du-rock-jour-3/)
 la déception («les petits rollercoasters malins de l’album sont ici enchaînés
 sans grande vie, semblent presque interchangeables, les morceaux semblent cloués
 au sol») et se moquaient même d'un [camel
@@ -61,7 +61,7 @@ soupçonner le groupe capable (_In My Head_ ou _Hold Your Hand_).
 Derrière les Dum Dum Girls, il serait difficile de parler de groupe. Il s'agit
 plutôt de Dee Dee
 (ex-[Grand Ole Party](http://www.youtube.com/watch?v=Xziod5qt03k)) et [des
-Ringo-ettes](277]. Il a donc bien fallu que Dee Dee s'entoure d'un bon
+Ringo-ettes](277). Il a donc bien fallu que Dee Dee s'entoure d'un bon
 producteur aux manettes de l'album. Elle en a même pris deux. Le premier
 s'appelle Richard Gottehrer, qui n'a jamais écrit [*Le
 Youki*->http://www.youtube.com/watch?v=Wx7vKvQ4axQ] ou [*Poil Au

--- a/2011/2011-10-25-dum-dum-girls-only-in-dreams.md
+++ b/2011/2011-10-25-dum-dum-girls-only-in-dreams.md
@@ -37,7 +37,7 @@ désagréable, mais derrière, pas grand chose. Les Inrocks avaient écrit
 la déception («les petits rollercoasters malins de l’album sont ici enchaînés
 sans grande vie, semblent presque interchangeables, les morceaux semblent cloués
 au sol») et se moquaient même d'un [camel
-toe)(http://fr.wikipedia.org/wiki/Cameltoe), les fripons. On n'était pas loin de
+toe](http://fr.wikipedia.org/wiki/Cameltoe), les fripons. On n'était pas loin de
 tirer un trait sur les Dum Dum Girls : sans doute un groupe opportuniste se
 lançant dans la brèche créée par [Best Coast](657), et qu'on aurait vite oublié.
 

--- a/2011/2011-10-25-dum-dum-girls-only-in-dreams.md
+++ b/2011/2011-10-25-dum-dum-girls-only-in-dreams.md
@@ -36,10 +36,11 @@ désagréable, mais derrière, pas grand chose. Les Inrocks avaient écrit
 [ici](http://www.lesinrocks.com/musique/musique-article/t/49359/date/2010-08-16/article/on-y-est-la-route-du-rock-jour-3/)
 la déception («les petits rollercoasters malins de l’album sont ici enchaînés
 sans grande vie, semblent presque interchangeables, les morceaux semblent cloués
-au sol») et se moquaient même d'un [camel
-toe](http://fr.wikipedia.org/wiki/Cameltoe), les fripons. On n'était pas loin de
-tirer un trait sur les Dum Dum Girls : sans doute un groupe opportuniste se
-lançant dans la brèche créée par [Best Coast](657), et qu'on aurait vite oublié.
+au sol») et se moquaient même d'un
+[camel toe](http://fr.wikipedia.org/wiki/Cameltoe), les fripons. On n'était pas
+loin de tirer un trait sur les Dum Dum Girls : sans doute un groupe opportuniste
+se lançant dans la brèche créée par [Best Coast](657), et qu'on aurait vite
+oublié.
 
 <img491>
 
@@ -60,17 +61,17 @@ soupçonner le groupe capable (_In My Head_ ou _Hold Your Hand_).
 
 Derrière les Dum Dum Girls, il serait difficile de parler de groupe. Il s'agit
 plutôt de Dee Dee
-(ex-[Grand Ole Party](http://www.youtube.com/watch?v=Xziod5qt03k)) et [des
-Ringo-ettes](277). Il a donc bien fallu que Dee Dee s'entoure d'un bon
+(ex-[Grand Ole Party](http://www.youtube.com/watch?v=Xziod5qt03k)) et
+[des Ringo-ettes](277). Il a donc bien fallu que Dee Dee s'entoure d'un bon
 producteur aux manettes de l'album. Elle en a même pris deux. Le premier
-s'appelle Richard Gottehrer, qui n'a jamais écrit [*Le
-Youki*->http://www.youtube.com/watch?v=Wx7vKvQ4axQ] ou [*Poil Au
-Tableau*->http://youtu.be/SghaF3fcflE], mais qui reste un vieux de la vieille
-puisqu'il a produit Blondie entre autres. Le second s'appelle Sune Rose Wagner,
-la tête à chromosome Y des [Raveonettes](mot209) et on se dit en écoutant
-l'intro de _Heartbeat (Take It Away)_ que le monsieur a dû peser de tout son
-poids (qui n'est plus négligeable si l'on se fie à [cette
-photo->http://en.wikipedia.org/wiki/File:Sune_Rose_Wagner_-_The_Raveonettes_-_Roskilde_Festival_2011.jpg))
+s'appelle Richard Gottehrer, qui n'a jamais écrit
+[_Le Youki_](http://www.youtube.com/watch?v=Wx7vKvQ4axQ) ou
+[_Poil Au Tableau_](http://youtu.be/SghaF3fcflE), mais qui reste un vieux de la
+vieille puisqu'il a produit Blondie entre autres. Le second s'appelle Sune Rose
+Wagner, la tête à chromosome Y des [Raveonettes](mot209) et on se dit en
+écoutant l'intro de _Heartbeat (Take It Away)_ que le monsieur a dû peser de
+tout son poids (qui n'est plus négligeable si l'on se fie à
+[cette photo](http://en.wikipedia.org/wiki/File:Sune_Rose_Wagner_-_The_Raveonettes_-_Roskilde_Festival_2011.jpg))
 dans la production des Dum Dum.
 
 Pour conclure, pourquoi "Dum Dum Girls" ? À cause de

--- a/2011/2011-11-03-les-disques-d-octobre-2011.md
+++ b/2011/2011-11-03-les-disques-d-octobre-2011.md
@@ -27,7 +27,7 @@ comments:
 ## Les 5 étoiles
 
 On en a déjà parlé [ici](936), Dum Dum Girls est incontestablement le disque du
-mois. Quant à Neutral Milk Hotel (évoqué [ici)(680) et [ici](687)), ils sont
+mois. Quant à Neutral Milk Hotel (évoqué [ici](680) et [ici](687)), ils sont
 sous les feux de la rampe puisqu'annonces de reformation et rééditions déboulent
 un peu partout. Si vous voulez investir dans les disques de Jeff Mangum et ses
 sbires, _In the Aeroplane, Over the Sea_ est à se procurer en priorité. Deux

--- a/2011/2011-11-03-les-disques-d-octobre-2011.md
+++ b/2011/2011-11-03-les-disques-d-octobre-2011.md
@@ -26,7 +26,7 @@ comments:
 
 ## Les 5 étoiles
 
-On en a déjà parlé [ici](936], Dum Dum Girls est incontestablement le disque du
+On en a déjà parlé [ici](936), Dum Dum Girls est incontestablement le disque du
 mois. Quant à Neutral Milk Hotel (évoqué [ici)(680) et [ici](687)), ils sont
 sous les feux de la rampe puisqu'annonces de reformation et rééditions déboulent
 un peu partout. Si vous voulez investir dans les disques de Jeff Mangum et ses

--- a/2011/2011-11-03-les-disques-d-octobre-2011.md
+++ b/2011/2011-11-03-les-disques-d-octobre-2011.md
@@ -27,7 +27,7 @@ comments:
 ## Les 5 étoiles
 
 On en a déjà parlé [ici](936], Dum Dum Girls est incontestablement le disque du
-mois. Quant à Neutral Milk Hotel (évoqué [ici](680) et [ici->687)), ils sont
+mois. Quant à Neutral Milk Hotel (évoqué [ici)(680) et [ici](687)), ils sont
 sous les feux de la rampe puisqu'annonces de reformation et rééditions déboulent
 un peu partout. Si vous voulez investir dans les disques de Jeff Mangum et ses
 sbires, _In the Aeroplane, Over the Sea_ est à se procurer en priorité. Deux

--- a/2011/2011-11-05-the-rolling-stones.md
+++ b/2011/2011-11-05-the-rolling-stones.md
@@ -43,9 +43,9 @@ gamin, il sniffait déjà les cendres de cigarettes de son père !
 
 Les deux compères ont accouché de formidables brûlots rock and roll, même si le
 duo est surtout connu pour ses "adaptations", qui en "empruntant"
-[*Roger*](http://www.youtube.com/watch?v=1a-EBGUapV8] aux **Rolling Bidochons**,
-qui en "rendant hommage" au **Eddy Mitchell** de [_Rien qu'un seul
-mot_->http://www.deezer.com/listen-1107661).
+[_Roger_](http://www.youtube.com/watch?v=1a-EBGUapV8) aux **Rolling Bidochons**,
+qui en "rendant hommage" au **Eddy Mitchell** de
+[_Rien qu'un seul mot_](http://www.deezer.com/listen-1107661).
 
 A côté de cette paire fantastique gravitent d'autres merveilleux individus : que
 ce soit Mick Jones, qui partit rapidement fonder le **Clash** ou Ron Wood,

--- a/2011/2011-12-03-les-disques-de-novembre-2011.md
+++ b/2011/2011-12-03-les-disques-de-novembre-2011.md
@@ -133,8 +133,8 @@ meilleur morceau.
 ### Wonderflu - _Lota Schwager_
 
 J'avais entendu beaucoup de choses en bien sur les Parisiens de Wonderflu
-[ici](829] et
-[là->http://blogs.lesinrocks.com/gimmeindierock/2011/10/06/vote-for-wonderflu/).
+[ici](829) et
+[là](http://blogs.lesinrocks.com/gimmeindierock/2011/10/06/vote-for-wonderflu/).
 Je m'y suis enfin penché et ai été légèrement déçu. Déjà, le cover art est très
 moche (police rouge sur fond bleu ? merde les gars, vous êtes pas sérieux !). Du
 classique un peu trop classique. Pas de quoi les condamner complètement non

--- a/2011/2011-12-09-guitar-army-john-sinclair.md
+++ b/2011/2011-12-09-guitar-army-john-sinclair.md
@@ -78,10 +78,10 @@ de drogues (autant dire qu'ils font du chiffre), les festivals qui finissent
 mal, ou les faits divers malheureux qui mettent du plomb dans l'aile de l'idéal
 communautaire hippie :
 
-- Les massacres de [Kent
-  State](http://en.wikipedia.org/wiki/Kent_State_shootings] (4 étudiants tués
-  par la garde nationale de l'Ohio lors d'un rassemblement pacifiste) et
-  [Jackson State->http://en.wikipedia.org/wiki/Jackson_State_killings)
+- Les massacres de
+  [Kent State](http://en.wikipedia.org/wiki/Kent_State_shootings) (4 étudiants
+  tués par la garde nationale de l'Ohio lors d'un rassemblement pacifiste) et
+  [Jackson State](http://en.wikipedia.org/wiki/Jackson_State_killings)
 - La [tuerie de Stonehead Manor][1] (un homme tua sa fille de 17 ans et 3 de ses
   amis car elle était hippie et vivait en communauté - l'homme en question fut
   condamné mais reçut des centaines de lettres de soutien)

--- a/2011/2011-12-12-best-coast-our-deal.md
+++ b/2011/2011-12-12-best-coast-our-deal.md
@@ -15,5 +15,5 @@ tags:
 
 Version longue de la vidéo réalisée par Drew Barrymore. Vous y reconnaîtrez
 Chloe Moretz (de [_Kick-Ass_](769) et [_500 Days Of Summer_](538)), et Alia
-Shawkat (d'[*Arrested Development*](934] et [_Bliss/Whip It_->769), le premier
+Shawkat (d'[*Arrested Development*](934) et [_Bliss/Whip It_->769), le premier
 film réalisé par Barrymore).

--- a/2011/2011-12-12-best-coast-our-deal.md
+++ b/2011/2011-12-12-best-coast-our-deal.md
@@ -14,6 +14,6 @@ tags:
 {% vimeo 27621823 %}
 
 Version longue de la vidéo réalisée par Drew Barrymore. Vous y reconnaîtrez
-Chloe Moretz (de [_Kick-Ass_](769) et [_500 Days Of Summer_](538]), et Alia
-Shawkat (d'[*Arrested Development*->934] et [_Bliss/Whip It_->769), le premier
+Chloe Moretz (de [_Kick-Ass_](769) et [_500 Days Of Summer_](538)), et Alia
+Shawkat (d'[*Arrested Development*](934] et [_Bliss/Whip It_->769), le premier
 film réalisé par Barrymore).

--- a/2011/2011-12-12-best-coast-our-deal.md
+++ b/2011/2011-12-12-best-coast-our-deal.md
@@ -15,5 +15,5 @@ tags:
 
 Version longue de la vidéo réalisée par Drew Barrymore. Vous y reconnaîtrez
 Chloe Moretz (de [_Kick-Ass_](769) et [_500 Days Of Summer_](538)), et Alia
-Shawkat (d'[*Arrested Development*](934) et [_Bliss/Whip It_->769), le premier
+Shawkat (d'[_Arrested Development_](934) et [_Bliss/Whip It_](769), le premier
 film réalisé par Barrymore).

--- a/2011/2011-12-13-bilan-dead-rooster-2011.md
+++ b/2011/2011-12-13-bilan-dead-rooster-2011.md
@@ -61,18 +61,18 @@ tous premiers posts du site) -# [Le nez de Dorothée sort de sa valise](553) -#
 
 Un constat s'impose, c'est bien marrant tout ça mais quid des vrais trésors de
 ce site ? Quid de [l'article de l'encyclopédie approximative de Jeff
-Buckley](831], de [la critique du second meilleur album de tous les temps](852),
-ou du [psycho-couac provoqué par la mort de Lucien Freud->876) ? Voilà de vrais
+Buckley](831], de [la critique du second meilleur album de tous les temps)(852),
+ou du [psycho-couac provoqué par la mort de Lucien Freud](876) ? Voilà de vrais
 trésors qu'il va nous falloir déterrer ! Nous y reviendrons la semaine prochaine
 dans un autre post intitulé "Feuille de route 2012 Dead Rooster", ou comment
 redonner le moral aux Français pour nous sortir de cette crise !
 
 ## Comment devenir un Ninja gratuitement ?
 
-Enfin, rigolons un peu. En s'inspirant de l'ouvrage [*Comment devenir un Ninja
-gratuitement*](http://www.amazon.fr/Comment-Devenir-Gratuitement-Josselin-Bordat/dp/2954063904/]
-et de [l'article que ça a inspiré aux
-Inrocks->http://www.lesinrocks.com/medias/numerique-article/t/72016/date/2011-10-24/article/coment-devenir-un-ninja-gratuitement/),
+Enfin, rigolons un peu. En s'inspirant de l'ouvrage
+[_Comment devenir un Ninja gratuitement_](http://www.amazon.fr/Comment-Devenir-Gratuitement-Josselin-Bordat/dp/2954063904/)
+et de
+[l'article que ça a inspiré aux Inrocks](http://www.lesinrocks.com/medias/numerique-article/t/72016/date/2011-10-24/article/coment-devenir-un-ninja-gratuitement/),
 allons-y à notre tour : palmarès des recherches Google ayant fini sur notre site
 les plus farfelues
 

--- a/2011/2011-12-13-bilan-dead-rooster-2011.md
+++ b/2011/2011-12-13-bilan-dead-rooster-2011.md
@@ -60,9 +60,10 @@ tous premiers posts du site) -# [Le nez de Dorothée sort de sa valise](553) -#
 [Hawaï mon cul ouais](497)
 
 Un constat s'impose, c'est bien marrant tout ça mais quid des vrais trésors de
-ce site ? Quid de [l'article de l'encyclopédie approximative de Jeff
-Buckley](831), de [la critique du second meilleur album de tous les temps](852),
-ou du [psycho-couac provoqué par la mort de Lucien Freud](876) ? Voilà de vrais
+ce site ? Quid de
+[l'article de l'encyclopédie approximative de Jeff Buckley](831), de
+[la critique du second meilleur album de tous les temps](852), ou du
+[psycho-couac provoqué par la mort de Lucien Freud](876) ? Voilà de vrais
 trésors qu'il va nous falloir déterrer ! Nous y reviendrons la semaine prochaine
 dans un autre post intitulé "Feuille de route 2012 Dead Rooster", ou comment
 redonner le moral aux Français pour nous sortir de cette crise !

--- a/2011/2011-12-13-bilan-dead-rooster-2011.md
+++ b/2011/2011-12-13-bilan-dead-rooster-2011.md
@@ -61,7 +61,7 @@ tous premiers posts du site) -# [Le nez de Dorothée sort de sa valise](553) -#
 
 Un constat s'impose, c'est bien marrant tout ça mais quid des vrais trésors de
 ce site ? Quid de [l'article de l'encyclopédie approximative de Jeff
-Buckley](831), de [la critique du second meilleur album de tous les temps)(852),
+Buckley](831), de [la critique du second meilleur album de tous les temps](852),
 ou du [psycho-couac provoqué par la mort de Lucien Freud](876) ? Voilà de vrais
 trésors qu'il va nous falloir déterrer ! Nous y reviendrons la semaine prochaine
 dans un autre post intitulé "Feuille de route 2012 Dead Rooster", ou comment

--- a/2011/2011-12-13-bilan-dead-rooster-2011.md
+++ b/2011/2011-12-13-bilan-dead-rooster-2011.md
@@ -61,7 +61,7 @@ tous premiers posts du site) -# [Le nez de Dorothée sort de sa valise](553) -#
 
 Un constat s'impose, c'est bien marrant tout ça mais quid des vrais trésors de
 ce site ? Quid de [l'article de l'encyclopédie approximative de Jeff
-Buckley](831], de [la critique du second meilleur album de tous les temps)(852),
+Buckley](831), de [la critique du second meilleur album de tous les temps)(852),
 ou du [psycho-couac provoqué par la mort de Lucien Freud](876) ? Voilà de vrais
 trésors qu'il va nous falloir déterrer ! Nous y reviendrons la semaine prochaine
 dans un autre post intitulé "Feuille de route 2012 Dead Rooster", ou comment

--- a/2011/2011-12-15-metta-world-peace-vs-captain-samourai-flower.md
+++ b/2011/2011-12-15-metta-world-peace-vs-captain-samourai-flower.md
@@ -8,8 +8,7 @@ cover: meta-world-peace.jpg
 date: 2011-12-15 01:51:32 +0100
 ---
 
-Ron Artest s'appelle désormais Metta World Peace et [se réjouit que les hommes
-perdent leurs dents quand ils sont bébés plutôt que quand ils ont 20 ou 30
-ans](http://chitwoodandhobbs.com/post/14199449976/let-them-lose-their-teeth-early].
-Je crois qu'il vient de déclarer la guerre à [Captain Samouraï Flower->543). Le
+Ron Artest s'appelle désormais Metta World Peace et
+[se réjouit que les hommes perdent leurs dents quand ils sont bébés plutôt que quand ils ont 20 ou 30 ans](http://chitwoodandhobbs.com/post/14199449976/let-them-lose-their-teeth-early).
+Je crois qu'il vient de déclarer la guerre à [Captain Samouraï Flower](543). Le
 monde va mal !

--- a/2011/2011-12-19-la-classe-de-retour.md
+++ b/2011/2011-12-19-la-classe-de-retour.md
@@ -10,6 +10,6 @@ date: 2011-12-19 12:57:51 +0100
 
 [La
 Classe](http://fr.wikipedia.org/wiki/La_Classe_(%C3%A9mission_de_t%C3%A9l%C3%A9vision)]
-sort [un album sur Tricatel](http://www.tricatel.com/) le 26 décembre. Ce sera
+sort [un album sur Tricatel)(http://www.tricatel.com/) le 26 décembre. Ce sera
 vraisemblablement sans Bézu. Et on est toujours sans nouvelle d'un opus de
-[Cocoricocoboy->http://fr.wikipedia.org/wiki/Cocoricocoboy). Le monde va mal !
+[Cocoricocoboy](http://fr.wikipedia.org/wiki/Cocoricocoboy). Le monde va mal !

--- a/2011/2011-12-19-la-classe-de-retour.md
+++ b/2011/2011-12-19-la-classe-de-retour.md
@@ -10,6 +10,6 @@ date: 2011-12-19 12:57:51 +0100
 
 [La
 Classe](http://fr.wikipedia.org/wiki/La_Classe_(%C3%A9mission_de_t%C3%A9l%C3%A9vision)]
-sort [un album sur Tricatel)(http://www.tricatel.com/) le 26 décembre. Ce sera
+sort [un album sur Tricatel](http://www.tricatel.com/) le 26 décembre. Ce sera
 vraisemblablement sans Bézu. Et on est toujours sans nouvelle d'un opus de
 [Cocoricocoboy](http://fr.wikipedia.org/wiki/Cocoricocoboy). Le monde va mal !

--- a/2011/2011-12-27-labrador-records.md
+++ b/2011/2011-12-27-labrador-records.md
@@ -25,10 +25,10 @@ les néo-babas psychés de la côte ouest ! Nous, ce qu'on veut, c'est de la pop
 sucrée, du Real Estate, du Youth Lagoon, tout ça ! (bon, on en reparlera).
 
 Mais surtout, ce que j'aime en ce moment (en fait, non, ça fait
-[quelques temps que ça dure](http://www.deadrooster.org/Parfois-on-s-demande]…),
+[quelques temps que ça dure](http://www.deadrooster.org/Parfois-on-s-demande)…),
 ce sont les groupes de pop suédois, mais pas genre ABBA ou Ace of Base ! Non !!!
 Moi, je fais dans le TTM version 2000/2010, messieurs-dames. Et pour ce faire,
-rien de tel que [Labrador Records->http://www.labrador.se/indexn.php3) ! (ah bah
+rien de tel que [Labrador Records](http://www.labrador.se/indexn.php3) ! (ah bah
 quand même ! 3 paragraphes pour arriver au sujet de l'article…)
 
 Et sur Labrador Records, label de pop suédois donc, il y a plein de groupes TTM

--- a/2012/2012-01-19-doubai-a-sochaux.md
+++ b/2012/2012-01-19-doubai-a-sochaux.md
@@ -8,8 +8,8 @@ cover: dubai-sochaux.png
 date: 2012-01-19 10:38:43 +0100
 ---
 
-L'Equipe l'affirme : [«Doubaï à
-Sochaux»](http://www.lequipe.fr/-/Actualites/-/256572]. Du coup, [la plus haute
-tour du monde->http://fr.wikipedia.org/wiki/Burj_Khalifa) est désormais en
-Franche-Comté ?! Les journalistes sont vraiment nuls en géographie. Le monde va
-mal !
+L'Equipe l'affirme :
+[«Doubaï à Sochaux»](http://www.lequipe.fr/-/Actualites/-/256572). Du coup,
+[la plus haute tour du monde](http://fr.wikipedia.org/wiki/Burj_Khalifa) est
+désormais en Franche-Comté ?! Les journalistes sont vraiment nuls en géographie.
+Le monde va mal !

--- a/2012/2012-01-27-top-music-2011.md
+++ b/2012/2012-01-27-top-music-2011.md
@@ -93,10 +93,10 @@ these music sites. Eh.
 
 For the rest, let's give a shoutout for M83 (a French band). We would've
 preferred something a bit more rock'n'roll - we're going to come off again as
-[French-Touchers](http://en.wikipedia.org/wiki/French_touch], but for once,
+[French-Touchers](http://en.wikipedia.org/wiki/French_touch), but for once,
 we're at the top, so I won't complain. Kanye and Drake are not really my cup of
 tea, so I won't dell. As for St. Vincent, I've already said what I thought
-[here->943).
+[here](943).
 
 The pleasant surprise comes perhaps from Destroyer, a potential candidate for
 the 2011 "Deerhunter" prize (re. a band I didn't know and only discovered in

--- a/2012/2012-02-05-les-disques-de-decembre-2011.md
+++ b/2012/2012-02-05-les-disques-de-decembre-2011.md
@@ -40,8 +40,8 @@ d'ouverture, _The Shakes_ est à la fois pop et sophistiqué, classe.
 
 ### Fleet Foxes - _Helplessness Blues_
 
-[Nos chouchous de 2008](222] sont revenus cette année avec un album dans la
-lignée directe de [son aîné->213). Du solide, donc, même si, l'effet de (bonne)
+[Nos chouchous de 2008](222) sont revenus cette année avec un album dans la
+lignée directe de [son aîné](213). Du solide, donc, même si, l'effet de (bonne)
 surprise n'étant plus là, l'enthousiasme n'est pas le même que pour le premier
 opus. Attendons le suivant pour voir ce que Robin Pecknold et ses sbires ont
 encore dans le ventre. Dommage que Willy DeVille soit mort (attention, blague
@@ -57,10 +57,10 @@ superbement exécuté.
 
 ### Bon Iver - _Bon Iver_
 
-Bon, c'est pas mal hein. D'ailleurs [tout le monde le dit](984]. N'empêche que
+Bon, c'est pas mal hein. D'ailleurs [tout le monde le dit](984). N'empêche que
 c'est trop travaillé, trop laborieux (au sens noble) pour s'y attacher
-complètement. Laurent Voulzy n'y verrait pas [un truc qui lui colle encore au
-coeur et au corps->http://www.youtube.com/watch?v=n9cOf8Qv8ts).
+complètement. Laurent Voulzy n'y verrait pas
+[un truc qui lui colle encore au coeur et au corps](http://www.youtube.com/watch?v=n9cOf8Qv8ts).
 
 ### Powersolo - _Buzz Human_
 
@@ -93,8 +93,8 @@ plaisir coupable à apprécier comme il se doit.
 ### The Mary Onettes - _Islands_
 
 On a dû écouter les Smiths par ici. Alors on tente de faire un peu les Smiths
-des années 2000. Sans avoir à en rougir. On en parle [ici](976] et on le fait
-écouter [là->972).
+des années 2000. Sans avoir à en rougir. On en parle [ici](976) et on le fait
+écouter [là](972).
 
 ### Grand Ole Party - _Under Our Skin_
 
@@ -146,9 +146,9 @@ tentez-l'écoute. Dans le cas contraire (le mien), laissez tomber.
 
 ### Esmerine - _La Lechuza_
 
-Le mec de [Bon pour les oreilles](http://www.bonpourlesoreilles.net/] me fait
+Le mec de [Bon pour les oreilles](http://www.bonpourlesoreilles.net/) me fait
 parfois découvrir de superbes groupes (le dernier récent étant Other Lives,
-diffusé depuis sur [le podcast #01->924)). D'autres fois, non. On est là dans la
+diffusé depuis sur [le podcast #01](924)). D'autres fois, non. On est là dans la
 2ème catégorie. Tant pis.
 
 ### Super Heavy - _Super Heavy_

--- a/2012/2012-02-08-lino-l-est-homme.md
+++ b/2012/2012-02-08-lino-l-est-homme.md
@@ -14,9 +14,8 @@ comments:
     content: pwo pwo pwo pwawawawawa… (…)
 ---
 
-Voilà [une information
-L'équipe](http://www.lequipe.fr/Tennis/Actualites/Li-na-jette-l-eponge/261774]
+Voilà
+[une information L'équipe](http://www.lequipe.fr/Tennis/Actualites/Li-na-jette-l-eponge/261774)
 qui va en décevoir beaucoup ! Cela veut dire que plus jamais nous ne pourrons
-[voir
-ça->http://www.ina.fr/economie-et-societe/vie-sociale/video/CAA81020718/debat-valery-giscard-d-estaing-francois-mitterrand.fr.html)
+[voir ça](http://www.ina.fr/economie-et-societe/vie-sociale/video/CAA81020718/debat-valery-giscard-d-estaing-francois-mitterrand.fr.html)
 ? Le monde va mal !

--- a/2012/2012-02-10-shaquiri-chat-qui-pleure.md
+++ b/2012/2012-02-10-shaquiri-chat-qui-pleure.md
@@ -16,9 +16,9 @@ comments:
       http://www.youtube.com/watch?v=E8Xu4i8RdR8
 ---
 
-L'Equipe nous le dit : [Shaqiri ira au
-Bayern](http://www.lequipe.fr/Football/Actualites/Shaqiri-ira-au-bayern/261903].
-Non seulement [Piqué doit faire la
-gueule->http://www.staragora.com/news/shakira-et-pique-bientot-maries/437945)
+L'Equipe nous le dit :
+[Shaqiri ira au Bayern](http://www.lequipe.fr/Football/Actualites/Shaqiri-ira-au-bayern/261903).
+Non seulement
+[Piqué doit faire la gueule](http://www.staragora.com/news/shakira-et-pique-bientot-maries/437945)
 mais, surtout, pas un mot sur les rumeurs qui enverraient Lady Guigui à l'AC
 Milan. Le monde va mal !

--- a/2012/2012-02-14-rip-whitney.md
+++ b/2012/2012-02-14-rip-whitney.md
@@ -10,5 +10,5 @@ date: 2012-02-14 14:42:30 +0100
 
 RIP Whitney Houston. Plusieurs jours après le décès de la chanteuse, on attend
 toujours les communiqués officiels de la
-[NASA](http://www.linternaute.com/histoire/categorie/evenement/46/1/a/47897/apollo_13_houston_on_a_un_probleme.shtml]
-et d'[Hakeem Olajuwon->http://youtu.be/CzUv5_YFhPI). Le monde va mal !
+[NASA](http://www.linternaute.com/histoire/categorie/evenement/46/1/a/47897/apollo_13_houston_on_a_un_probleme.shtml)
+et d'[Hakeem Olajuwon](http://youtu.be/CzUv5_YFhPI). Le monde va mal !

--- a/2012/2012-02-23-le-parti-opportuniste.md
+++ b/2012/2012-02-23-le-parti-opportuniste.md
@@ -1,10 +1,6 @@
 ---
 layout: post
 title: Le parti opportuniste
-description:
-  En attendant les premiers épisodes de {La Visite du Louvre}, [promis il y a
-  déjà quelques temps->975], voici un coup d'essai de BD inspiré d'un billet de
-  François Morel sur France Inter.
 authors:
   - Dirty Henry
 wordpress_id: 998

--- a/2012/2012-03-13-merci-mon-dieu-pour-le-foot.md
+++ b/2012/2012-03-13-merci-mon-dieu-pour-le-foot.md
@@ -8,9 +8,8 @@ cover: foot-i-belong-to-jesus.jpg
 date: 2012-03-13 20:07:22 +0100
 ---
 
-C'est avec tristesse que l'on apprend [les échauffourées ayant eu lieu au cours
-de la Clericus Cup
-](http://bigbrowser.blog.lemonde.fr/2012/03/13/vatican-foot/#xtor=RSS-32280322].
-Il semblerait cependant qu'aucune [sainte
-grenade->http://www.youtube.com/watch?v=xOrgLj9lOwk) n'ait été dégoupillée. Mais
-tout de même… Le monde va mal !
+C'est avec tristesse que l'on apprend
+[les échauffourées ayant eu lieu au cours de la Clericus Cup ](http://bigbrowser.blog.lemonde.fr/2012/03/13/vatican-foot/#xtor=RSS-32280322).
+Il semblerait cependant qu'aucune
+[sainte grenade](http://www.youtube.com/watch?v=xOrgLj9lOwk) n'ait été
+dégoupillée. Mais tout de même… Le monde va mal !

--- a/2012/2012-03-14-mais-c-est-degeulaaasse.md
+++ b/2012/2012-03-14-mais-c-est-degeulaaasse.md
@@ -8,10 +8,10 @@ cover: paire-de-ciseaux.jpg
 date: 2012-03-14 23:49:26 +0100
 ---
 
-Les [Scissor
-Sisters](http://www.urbandictionary.com/define.php?term=scissor%20sisters)
-annoncent [un nouvel
-album](http://pitchfork.com/news/45742-scissor-sisters-announce-new-album/).
+Les
+[Scissor Sisters](http://www.urbandictionary.com/define.php?term=scissor%20sisters)
+annoncent
+[un nouvel album](http://pitchfork.com/news/45742-scissor-sisters-announce-new-album/).
 Toujours aucune nouvelle de
 [Dirty Sanchez](http://www.urbandictionary.com/define.php?term=dirty+sanchez).
 Le monde va mal !

--- a/2012/2012-03-14-mais-c-est-degeulaaasse.md
+++ b/2012/2012-03-14-mais-c-est-degeulaaasse.md
@@ -10,8 +10,8 @@ date: 2012-03-14 23:49:26 +0100
 
 Les [Scissor
 Sisters](http://www.urbandictionary.com/define.php?term=scissor%20sisters]
-annoncent
-[un nouvel album](http://pitchfork.com/news/45742-scissor-sisters-announce-new-album/).
-Toujours aucune nouvelle de [Dirty
-Sanchez->http://www.urbandictionary.com/define.php?term=dirty+sanchez). Le monde
-va mal !
+annoncent [un nouvel
+album)(http://pitchfork.com/news/45742-scissor-sisters-announce-new-album/).
+Toujours aucune nouvelle de
+[Dirty Sanchez](http://www.urbandictionary.com/define.php?term=dirty+sanchez).
+Le monde va mal !

--- a/2012/2012-03-14-mais-c-est-degeulaaasse.md
+++ b/2012/2012-03-14-mais-c-est-degeulaaasse.md
@@ -11,7 +11,7 @@ date: 2012-03-14 23:49:26 +0100
 Les [Scissor
 Sisters](http://www.urbandictionary.com/define.php?term=scissor%20sisters)
 annoncent [un nouvel
-album)(http://pitchfork.com/news/45742-scissor-sisters-announce-new-album/).
+album](http://pitchfork.com/news/45742-scissor-sisters-announce-new-album/).
 Toujours aucune nouvelle de
 [Dirty Sanchez](http://www.urbandictionary.com/define.php?term=dirty+sanchez).
 Le monde va mal !

--- a/2012/2012-03-14-mais-c-est-degeulaaasse.md
+++ b/2012/2012-03-14-mais-c-est-degeulaaasse.md
@@ -9,7 +9,7 @@ date: 2012-03-14 23:49:26 +0100
 ---
 
 Les [Scissor
-Sisters](http://www.urbandictionary.com/define.php?term=scissor%20sisters]
+Sisters](http://www.urbandictionary.com/define.php?term=scissor%20sisters)
 annoncent [un nouvel
 album)(http://pitchfork.com/news/45742-scissor-sisters-announce-new-album/).
 Toujours aucune nouvelle de

--- a/2012/2012-03-26-belle-and-sebastian-crash.md
+++ b/2012/2012-03-26-belle-and-sebastian-crash.md
@@ -12,9 +12,9 @@ pour la série des Late Night Tales.
 
 {% youtube rSBVvFU55fg %}
 
-Sinon, n'oublions pas de regarder [*Dumb And
-Dumber*](http://www.youtube.com/watch?v=Bf92Y4CQ3DA] tous les ans (dans [la
-version "petite vieille"-included->576) bien sûr).
+Sinon, n'oublions pas de regarder
+[_Dumb And Dumber_](http://www.youtube.com/watch?v=Bf92Y4CQ3DA) tous les ans
+(dans [la version "petite vieille"-included](576) bien sûr).
 
 (via
 [Pitchfork](http://pitchfork.com/news/45899-video-belle-and-sebastian-crash/))

--- a/2012/2012-04-01-foot-et-litterature-2.md
+++ b/2012/2012-04-01-foot-et-litterature-2.md
@@ -8,8 +8,8 @@ cover: victor-hugo-2.jpg
 date: 2012-04-01 23:08:00 +0200
 ---
 
-[Lors d'un précédent article](http://www.deadrooster.org/Foot-et-litterature],
+[Lors d'un précédent article](http://www.deadrooster.org/Foot-et-litterature),
 on s'interrogeait sur la carrière footballistique de Victor Hugo. Eh bien,
-soyons rassurés, [il joue à
-Rennes->http://www.lequipe.fr/Football/FootballFicheJoueur20726.html) ! Par
-contre, qu'a-t-il fait de son emblématique barbe ? Le monde va mal !
+soyons rassurés,
+[il joue à Rennes](http://www.lequipe.fr/Football/FootballFicheJoueur20726.html)
+! Par contre, qu'a-t-il fait de son emblématique barbe ? Le monde va mal !

--- a/2012/2012-04-18-une-carte-mystere.md
+++ b/2012/2012-04-18-une-carte-mystere.md
@@ -11,7 +11,7 @@ Dans
 [l'exposition consacrée à Bob Dylan](http://www.citedelamusique.fr/minisites/1203_dylan/index.aspx)
 actuellement à la Cité de la Musique, on apprend que le musicien est natif de
 Duluth, Minnesota. Mais ce que l'on ne nous dit pas, c'est que l'album [Highway
-61 Revisited](http://fr.wikipedia.org/wiki/Highway_61_Revisited] lui coûta [pas
+61 Revisited](http://fr.wikipedia.org/wiki/Highway_61_Revisited) lui coûta [pas
 moins de 3 wagons verts, 2 wagons blancs, 3 wagons rouges et 2 cartes
 loco->http://www.asmodee.com/ressources/articles/les-aventuriers-du-rail-les-techniques-des-champions.php)
 ! Le monde va mal !

--- a/2012/2012-04-18-une-carte-mystere.md
+++ b/2012/2012-04-18-une-carte-mystere.md
@@ -10,8 +10,8 @@ date: 2012-04-18 10:25:46 +0200
 Dans
 [l'exposition consacrée à Bob Dylan](http://www.citedelamusique.fr/minisites/1203_dylan/index.aspx)
 actuellement à la Cité de la Musique, on apprend que le musicien est natif de
-Duluth, Minnesota. Mais ce que l'on ne nous dit pas, c'est que l'album [Highway
-61 Revisited](http://fr.wikipedia.org/wiki/Highway_61_Revisited) lui coûta [pas
-moins de 3 wagons verts, 2 wagons blancs, 3 wagons rouges et 2 cartes
-loco->http://www.asmodee.com/ressources/articles/les-aventuriers-du-rail-les-techniques-des-champions.php)
+Duluth, Minnesota. Mais ce que l'on ne nous dit pas, c'est que l'album
+[Highway 61 Revisited](http://fr.wikipedia.org/wiki/Highway_61_Revisited) lui
+coûta
+[pas moins de 3 wagons verts, 2 wagons blancs, 3 wagons rouges et 2 cartes loco](http://www.asmodee.com/ressources/articles/les-aventuriers-du-rail-les-techniques-des-champions.php)
 ! Le monde va mal !

--- a/2012/2012-04-18-une-carte-mystere.md
+++ b/2012/2012-04-18-une-carte-mystere.md
@@ -7,11 +7,11 @@ cover: les-aventuriers-du-rail.jpg
 date: 2012-04-18 10:25:46 +0200
 ---
 
-Dans [l'exposition consacrée à Bob
-Dylan](http://www.citedelamusique.fr/minisites/1203_dylan/index.aspx]
+Dans
+[l'exposition consacrée à Bob Dylan](http://www.citedelamusique.fr/minisites/1203_dylan/index.aspx)
 actuellement à la Cité de la Musique, on apprend que le musicien est natif de
 Duluth, Minnesota. Mais ce que l'on ne nous dit pas, c'est que l'album [Highway
-61 Revisited->http://fr.wikipedia.org/wiki/Highway_61_Revisited] lui coûta [pas
+61 Revisited](http://fr.wikipedia.org/wiki/Highway_61_Revisited] lui coûta [pas
 moins de 3 wagons verts, 2 wagons blancs, 3 wagons rouges et 2 cartes
 loco->http://www.asmodee.com/ressources/articles/les-aventuriers-du-rail-les-techniques-des-champions.php)
 ! Le monde va mal !

--- a/2012/2012-04-20-nana-was-there.md
+++ b/2012/2012-04-20-nana-was-there.md
@@ -8,7 +8,7 @@ cover: nana-mouskouri.jpg
 date: 2012-04-20 20:09:00 +0200
 ---
 
-[N'Arnold n'et Willy](http://www.youtube.com/watch?v=lRNCLUBJk08] n'ont rien
+[N'Arnold n'et Willy](http://www.youtube.com/watch?v=lRNCLUBJk08) n'ont rien
 n'inventé. Nana n'était là n'avant, [la
 preuve)(http://www.youtube.com/watch?v=VO0qGaOvIUA) ! Pardon, je parle du nez,
 mais j'ai

--- a/2012/2012-04-20-nana-was-there.md
+++ b/2012/2012-04-20-nana-was-there.md
@@ -9,7 +9,8 @@ date: 2012-04-20 20:09:00 +0200
 ---
 
 [N'Arnold n'et Willy](http://www.youtube.com/watch?v=lRNCLUBJk08] n'ont rien
-n'inventé. Nana n'était là n'avant,
-[la preuve](http://www.youtube.com/watch?v=VO0qGaOvIUA) ! Pardon, je parle du
-nez, mais j'ai [un n'haricot dans
-l'oreille->http://www.youtube.com/watch?v=KUScX45eW80) ! Le monde va mal !
+n'inventé. Nana n'était là n'avant, [la
+preuve)(http://www.youtube.com/watch?v=VO0qGaOvIUA) ! Pardon, je parle du nez,
+mais j'ai
+[un n'haricot dans l'oreille](http://www.youtube.com/watch?v=KUScX45eW80) ! Le
+monde va mal !

--- a/2012/2012-04-20-nana-was-there.md
+++ b/2012/2012-04-20-nana-was-there.md
@@ -9,8 +9,8 @@ date: 2012-04-20 20:09:00 +0200
 ---
 
 [N'Arnold n'et Willy](http://www.youtube.com/watch?v=lRNCLUBJk08) n'ont rien
-n'inventé. Nana n'était là n'avant, [la
-preuve](http://www.youtube.com/watch?v=VO0qGaOvIUA) ! Pardon, je parle du nez,
-mais j'ai
+n'inventé. Nana n'était là n'avant,
+[la preuve](http://www.youtube.com/watch?v=VO0qGaOvIUA) ! Pardon, je parle du
+nez, mais j'ai
 [un n'haricot dans l'oreille](http://www.youtube.com/watch?v=KUScX45eW80) ! Le
 monde va mal !

--- a/2012/2012-04-20-nana-was-there.md
+++ b/2012/2012-04-20-nana-was-there.md
@@ -10,7 +10,7 @@ date: 2012-04-20 20:09:00 +0200
 
 [N'Arnold n'et Willy](http://www.youtube.com/watch?v=lRNCLUBJk08) n'ont rien
 n'inventé. Nana n'était là n'avant, [la
-preuve)(http://www.youtube.com/watch?v=VO0qGaOvIUA) ! Pardon, je parle du nez,
+preuve](http://www.youtube.com/watch?v=VO0qGaOvIUA) ! Pardon, je parle du nez,
 mais j'ai
 [un n'haricot dans l'oreille](http://www.youtube.com/watch?v=KUScX45eW80) ! Le
 monde va mal !

--- a/2012/2012-05-11-poutre-dans-l-oeil.md
+++ b/2012/2012-05-11-poutre-dans-l-oeil.md
@@ -8,9 +8,7 @@ cover: bug-lequipe.png
 date: 2012-05-11 20:10:18 +0200
 ---
 
-[L'Équipe se moque d'une faute d'orthographe sur le maillot de
-l'OM](http://www.lequipe.fr/Football/Actualites/Une-fote-sur-le-maillot/283026].
-Une occasion inespérée de célébrer une expression beaucoup trop rare : ["voir la
-paille dans l'oeil du voisin et ne pas voir la poutre dans le
-sien"->http://fr.wiktionary.org/wiki/voir_la_paille_dans_l%E2%80%99%C5%93il_du_voisin_et_ne_pas_voir_la_poutre_dans_le_sien).
+[L'Équipe se moque d'une faute d'orthographe sur le maillot de l'OM](http://www.lequipe.fr/Football/Actualites/Une-fote-sur-le-maillot/283026).
+Une occasion inespérée de célébrer une expression beaucoup trop rare :
+["voir la paille dans l'oeil du voisin et ne pas voir la poutre dans le sien"](http://fr.wiktionary.org/wiki/voir_la_paille_dans_l%E2%80%99%C5%93il_du_voisin_et_ne_pas_voir_la_poutre_dans_le_sien).
 Le monde va mal !

--- a/2012/2012-05-31-de-toute-facon-ca-tombera-pas-c-est-hors-programme.md
+++ b/2012/2012-05-31-de-toute-facon-ca-tombera-pas-c-est-hors-programme.md
@@ -11,8 +11,7 @@ tags:
   - Trucs marrants
 ---
 
-[Le doyen du bac cette année a 87
-ans](http://www.lepoint.fr/societe/bac-le-doyen-national-des-candidats-est-un-perigourdin-de-87-ans-23-05-2012-1464591_23.php].
-A l'ère des smartphones, honte sur lui s'il ignore que [Nicolas IV n'est plus le
-tsar de toutes les Russies->http://www.youtube.com/watch?v=zxEgybebT5I). Le
-monde va mal !
+[Le doyen du bac cette année a 87 ans](http://www.lepoint.fr/societe/bac-le-doyen-national-des-candidats-est-un-perigourdin-de-87-ans-23-05-2012-1464591_23.php).
+A l'ère des smartphones, honte sur lui s'il ignore que
+[Nicolas IV n'est plus le tsar de toutes les Russies](http://www.youtube.com/watch?v=zxEgybebT5I).
+Le monde va mal !

--- a/2012/2012-06-21-help-me-gibler.md
+++ b/2012/2012-06-21-help-me-gibler.md
@@ -14,7 +14,6 @@ tags:
   - The Beach Boys
 ---
 
-[Oncle Jesse](http://fr.wikipedia.org/wiki/La_F%C3%AAte_%C3%A0_la_maison] ne
-joue pas dans le dernier clip des Beach Boys. Le monde va mal ! (via [Stereogum,
-à qui j'ai piqué la
-blague->http://stereogum.com/1069442/the-beach-boys-thats-why-god-made-the-radio-video))
+[Oncle Jesse](http://fr.wikipedia.org/wiki/La_F%C3%AAte_%C3%A0_la_maison) ne
+joue pas dans le dernier clip des Beach Boys. Le monde va mal ! (via
+[Stereogum, à qui j'ai piqué la blague](http://stereogum.com/1069442/the-beach-boys-thats-why-god-made-the-radio-video))

--- a/2012/2012-08-30-fumee-dans-les-oreilles.md
+++ b/2012/2012-08-30-fumee-dans-les-oreilles.md
@@ -12,7 +12,7 @@ tags:
   - Reprise
 ---
 
-Oubliez [*Last Nite* par les Morning Benders ou *Yesterday* en reggae](878], les
-Flaming Lips font encore plus fort et signent avec [_Smoke On The
-Water_->http://musique.premiere.fr/News-Musique/Les-Flaming-Lips-reprennent-Smoke-on-the-Water-de-Deep-Purple-3468346)
+Oubliez [_Last Nite_ par les Morning Benders ou _Yesterday_ en reggae](878), les
+Flaming Lips font encore plus fort et signent avec
+[_Smoke On The Water_](http://musique.premiere.fr/News-Musique/Les-Flaming-Lips-reprennent-Smoke-on-the-Water-de-Deep-Purple-3468346)
 la pire reprise de l'histoire. Le monde va mal !

--- a/2012/2012-09-05-meme-plus-tranquille-chez-soi-vol-2.md
+++ b/2012/2012-09-05-meme-plus-tranquille-chez-soi-vol-2.md
@@ -8,7 +8,7 @@ cover: poele.jpg
 date: 2012-09-05 08:00:00 +0200
 ---
 
-[Bono avait déjà été emmerdé chez lui il y a 4 ans](457], maintenant voilà
-qu'[une pauvre femme se fait interpeler 4 fois par la police pour écouter du
-AC/DC->http://www.nme.com/news/acdc/65882). Bon, ok, elle a aussi jeté une poêle
-à frire sur son neveu mais quand même ! Le monde va mal !
+[Bono avait déjà été emmerdé chez lui il y a 4 ans](457), maintenant voilà
+qu'[une pauvre femme se fait interpeler 4 fois par la police pour écouter du AC/DC](http://www.nme.com/news/acdc/65882).
+Bon, ok, elle a aussi jeté une poêle à frire sur son neveu mais quand même ! Le
+monde va mal !

--- a/2012/2012-09-11-social-square-as-they-come.md
+++ b/2012/2012-09-11-social-square-as-they-come.md
@@ -10,5 +10,5 @@ date: "2012-09-11 08:00:00 +0200"
 <iframe width="100%" height="450" scrolling="no" frameborder="no" src="http://w.soundcloud.com/player/?url=http%3A%2F%2Fapi.soundcloud.com%2Fplaylists%2F2156884&show_artwork=true"></iframe>
 
 Le nouveau EP 3-titres de Social Square, _Carrying On_, est
-[disponible](http://soundcloud.com/social-square/sets/3-new-songs-3/]. C'est
-l'occasion de relire [le DIY qui leur a été consacré->829).
+[disponible](http://soundcloud.com/social-square/sets/3-new-songs-3/). C'est
+l'occasion de relire [le DIY qui leur a été consacré](829).

--- a/2012/2012-09-29-mamie-blue.md
+++ b/2012/2012-09-29-mamie-blue.md
@@ -9,6 +9,7 @@ date: 2012-09-29 09:33:34 +0200
 ---
 
 D'après une info de L'équipe,
-[Nicolita](http://www.lequipe.fr/Football/Actualites/Nicolita-absent-quatre-semaines/316254]
-sera absent plusieurs semaines des terrains de foot. Là, c'est officiel, [il est
-mort le soleil->http://www.youtube.com/watch?v=wM2k_RjNnDU). Le monde va mal !
+[Nicolita](http://www.lequipe.fr/Football/Actualites/Nicolita-absent-quatre-semaines/316254)
+sera absent plusieurs semaines des terrains de foot. Là, c'est officiel,
+[il est mort le soleil](http://www.youtube.com/watch?v=wM2k_RjNnDU). Le monde va
+mal !

--- a/2012/2012-10-02-up-in-the-beach.md
+++ b/2012/2012-10-02-up-in-the-beach.md
@@ -9,7 +9,7 @@ date: 2012-10-02 22:41:39 +0200
 ---
 
 [Mike Love a décidé de virer Brian Wilson des Beach
-Boys](http://pitchfork.com/news/48008-beach-boys-mike-love-kicks-brian-wilson-al-jardine-and-david-marks-out-of-the-band/].
+Boys](http://pitchfork.com/news/48008-beach-boys-mike-love-kicks-brian-wilson-al-jardine-and-david-marks-out-of-the-band/).
 C'est un peu comme si [Pete Best)(http://fr.wikipedia.org/wiki/Pete_Best) et
 [Stuart Sutcliffe](http://fr.wikipedia.org/wiki/Stuart_Sutcliffe) avaient décidé
 de virer Paul McCartney et John Lennon des Beatles. Le monde va mal !

--- a/2012/2012-10-02-up-in-the-beach.md
+++ b/2012/2012-10-02-up-in-the-beach.md
@@ -10,6 +10,6 @@ date: 2012-10-02 22:41:39 +0200
 
 [Mike Love a décidé de virer Brian Wilson des Beach
 Boys](http://pitchfork.com/news/48008-beach-boys-mike-love-kicks-brian-wilson-al-jardine-and-david-marks-out-of-the-band/].
-C'est un peu comme si [Pete Best](http://fr.wikipedia.org/wiki/Pete_Best) et
-[Stuart Sutcliffe->http://fr.wikipedia.org/wiki/Stuart_Sutcliffe) avaient décidé
+C'est un peu comme si [Pete Best)(http://fr.wikipedia.org/wiki/Pete_Best) et
+[Stuart Sutcliffe](http://fr.wikipedia.org/wiki/Stuart_Sutcliffe) avaient décidé
 de virer Paul McCartney et John Lennon des Beatles. Le monde va mal !

--- a/2012/2012-10-02-up-in-the-beach.md
+++ b/2012/2012-10-02-up-in-the-beach.md
@@ -10,6 +10,6 @@ date: 2012-10-02 22:41:39 +0200
 
 [Mike Love a décidé de virer Brian Wilson des Beach
 Boys](http://pitchfork.com/news/48008-beach-boys-mike-love-kicks-brian-wilson-al-jardine-and-david-marks-out-of-the-band/).
-C'est un peu comme si [Pete Best)(http://fr.wikipedia.org/wiki/Pete_Best) et
+C'est un peu comme si [Pete Best](http://fr.wikipedia.org/wiki/Pete_Best) et
 [Stuart Sutcliffe](http://fr.wikipedia.org/wiki/Stuart_Sutcliffe) avaient décidé
 de virer Paul McCartney et John Lennon des Beatles. Le monde va mal !

--- a/2012/2012-10-02-up-in-the-beach.md
+++ b/2012/2012-10-02-up-in-the-beach.md
@@ -8,8 +8,7 @@ cover: stuart-pete-beatles-montage.png
 date: 2012-10-02 22:41:39 +0200
 ---
 
-[Mike Love a décidé de virer Brian Wilson des Beach
-Boys](http://pitchfork.com/news/48008-beach-boys-mike-love-kicks-brian-wilson-al-jardine-and-david-marks-out-of-the-band/).
+[Mike Love a décidé de virer Brian Wilson des Beach Boys](http://pitchfork.com/news/48008-beach-boys-mike-love-kicks-brian-wilson-al-jardine-and-david-marks-out-of-the-band/).
 C'est un peu comme si [Pete Best](http://fr.wikipedia.org/wiki/Pete_Best) et
 [Stuart Sutcliffe](http://fr.wikipedia.org/wiki/Stuart_Sutcliffe) avaient décidé
 de virer Paul McCartney et John Lennon des Beatles. Le monde va mal !

--- a/2012/2012-10-09-moeurs-legeres.md
+++ b/2012/2012-10-09-moeurs-legeres.md
@@ -10,9 +10,9 @@ date: 2012-10-09 19:12:37 +0200
 
 Ke\$ha a fait [l'amour avec un fantôme](http://www.nme.com/news/keha/66332)
 ([Patrick Swayze ?](http://www.dailymotion.com/video/xtlhdf_ghost-patrick-swayze-demi-moore-whoopi-goldberg-scena-finale-www-goodnews-ws_shortfilms))
-et Pete Townshend déclare que [le sexe de Mick Jagger est «long et
-potelé»->http://www.nme.com/news/the-who/66340). Keith Richards avait pourtant
-déclaré que
+et Pete Townshend déclare que
+[le sexe de Mick Jagger est «long et potelé»](http://www.nme.com/news/the-who/66340).
+Keith Richards avait pourtant déclaré que
 [l'organe de son partenaire des Rolling Stones était très petit](http://www.nme.com/news/the-rolling-stones/62658).
 On ne sait donc plus du tout qui croire et on commence à croire que les stars du
 rock racontent parfois n'importe quoi. Le monde va mal !

--- a/2012/2012-10-09-moeurs-legeres.md
+++ b/2012/2012-10-09-moeurs-legeres.md
@@ -9,7 +9,7 @@ date: 2012-10-09 19:12:37 +0200
 ---
 
 Ke\$ha a fait [l'amour avec un fantôme](http://www.nme.com/news/keha/66332)
-([Patrick Swayze ?](http://www.dailymotion.com/video/xtlhdf_ghost-patrick-swayze-demi-moore-whoopi-goldberg-scena-finale-www-goodnews-ws_shortfilms])
+([Patrick Swayze ?](http://www.dailymotion.com/video/xtlhdf_ghost-patrick-swayze-demi-moore-whoopi-goldberg-scena-finale-www-goodnews-ws_shortfilms))
 et Pete Townshend déclare que [le sexe de Mick Jagger est «long et
 potelé»->http://www.nme.com/news/the-who/66340). Keith Richards avait pourtant
 déclaré que

--- a/2012/2012-10-09-moeurs-legeres.md
+++ b/2012/2012-10-09-moeurs-legeres.md
@@ -8,12 +8,11 @@ cover: hamster-jovial-pipi-comic.png
 date: 2012-10-09 19:12:37 +0200
 ---
 
-Ke\$ha a fait [l'amour avec un fantôme](http://www.nme.com/news/keha/66332]
-([Patrick Swayze
-?->http://www.dailymotion.com/video/xtlhdf_ghost-patrick-swayze-demi-moore-whoopi-goldberg-scena-finale-www-goodnews-ws_shortfilms])
+Ke\$ha a fait [l'amour avec un fantôme](http://www.nme.com/news/keha/66332)
+([Patrick Swayze ?](http://www.dailymotion.com/video/xtlhdf_ghost-patrick-swayze-demi-moore-whoopi-goldberg-scena-finale-www-goodnews-ws_shortfilms])
 et Pete Townshend déclare que [le sexe de Mick Jagger est «long et
-potelé»->http://www.nme.com/news/the-who/66340]. Keith Richards avait pourtant
-déclaré que [l'organe de son partenaire des Rolling Stones était très
-petit->http://www.nme.com/news/the-rolling-stones/62658). On ne sait donc plus
-du tout qui croire et on commence à croire que les stars du rock racontent
-parfois n'importe quoi. Le monde va mal !
+potelé»->http://www.nme.com/news/the-who/66340). Keith Richards avait pourtant
+déclaré que
+[l'organe de son partenaire des Rolling Stones était très petit](http://www.nme.com/news/the-rolling-stones/62658).
+On ne sait donc plus du tout qui croire et on commence à croire que les stars du
+rock racontent parfois n'importe quoi. Le monde va mal !

--- a/2012/2012-10-26-tsool-mais-trop-t-sais.md
+++ b/2012/2012-10-26-tsool-mais-trop-t-sais.md
@@ -48,7 +48,7 @@ moustache…).
 
 {% youtube -2SRfj-l65o %}
 
-Ensuite, il y a eu [cet album](http://www.deezer.com/fr/album/1668777], sorti au
+Ensuite, il y a eu [cet album](http://www.deezer.com/fr/album/1668777), sorti au
 milieu de l'été et dont le groupe avait déjà joué pas mal de morceaux à Paris
 (au passage, c'est assez triste de voir que ni Allmusic, ni le Wikipédia
 français n'en parle…). Sans surprise, le disque est globalement formidable, avec

--- a/2012/2012-10-31-les-gunnuls.md
+++ b/2012/2012-10-31-les-gunnuls.md
@@ -8,8 +8,8 @@ cover: arsene-wenger-grimace.jpg
 date: 2012-10-31 09:04:39 +0100
 ---
 
-Alors que Paul-Henri Mathieu n'a mis [qu'à peine plus de 90 minutes pour
-remporter un set 7-5](http://www.lequipe.fr/Tennis/MatchDirect/131563.html], il
-aura fallu plus de 120 minutes à [Arsenal pour en faire
-autant->http://www.lequipe.fr/Football/Actualites/Arsenal-et-la-folle-remontee/323424)…
+Alors que Paul-Henri Mathieu n'a mis
+[qu'à peine plus de 90 minutes pour remporter un set 7-5](http://www.lequipe.fr/Tennis/MatchDirect/131563.html),
+il aura fallu plus de 120 minutes à
+[Arsenal pour en faire autant](http://www.lequipe.fr/Football/Actualites/Arsenal-et-la-folle-remontee/323424)…
 Mais que fait Arsène ? Le monde va mal !

--- a/2012/2012-11-15-veronica-falls-teenage.md
+++ b/2012/2012-11-15-veronica-falls-teenage.md
@@ -7,8 +7,8 @@ wordpress_id: 1137
 date: "2012-11-15 08:00:00 +0100"
 ---
 
-Le 2nd album de [nos chouchous de 2011](984], _Waiting For Something To Happen_,
-sortira début 2013. Vous pouvez aussi [réécouter _My Heart Beats_->1011).
+Le 2nd album de [nos chouchous de 2011](984), _Waiting For Something To Happen_,
+sortira début 2013. Vous pouvez aussi [réécouter _My Heart Beats_](1011).
 
 <iframe width="100%" height="166" scrolling="no" frameborder="no" src="http://w.soundcloud.com/player/?url=http%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F66749368&show_artwork=true"></iframe>
 

--- a/2012/2012-12-01-la-vie-en-bleu.md
+++ b/2012/2012-12-01-la-vie-en-bleu.md
@@ -8,8 +8,8 @@ cover: michou.jpg
 date: 2012-12-01 22:20:00 +0100
 ---
 
-Aujourd'hui, [Michu a réalisé le
-doublé](http://www.lequipe.fr/Football/Actualites/Arsenal-swansea-city-0-2/330811]
-face à Arsenal. Pas sûr que les hommes de Wenger passent [une belle
-soirée->http://www.dailymotion.com/video/xp5iz_jonathan-lambert-michou_fun). Le
-monde va mal !
+Aujourd'hui,
+[Michu a réalisé le doublé](http://www.lequipe.fr/Football/Actualites/Arsenal-swansea-city-0-2/330811)
+face à Arsenal. Pas sûr que les hommes de Wenger passent
+[une belle soirée](http://www.dailymotion.com/video/xp5iz_jonathan-lambert-michou_fun).
+Le monde va mal !

--- a/2012/2012-12-28-vikash-vous-zlatane-tous.md
+++ b/2012/2012-12-28-vikash-vous-zlatane-tous.md
@@ -22,8 +22,8 @@ coupe du monde 2010 sous le beau soleil d'Allemagne, on disait de quelqu'un qui
 avait joliment bronzé qu'il avait _dhorasooé_. Le langage SMS l'a transformé en
 "dorer à souhait" et on ne l'utilise guère plus qu'en cuisine. Le monde va mal !
 
-ps : on pensera aussi à [llacerer](http://fr.wikipedia.org/wiki/Francis_Llacer]
+ps : on pensera aussi à [llacerer](http://fr.wikipedia.org/wiki/Francis_Llacer)
 (dont on a enlevé le premier 'l' pour des raisons évidentes) dont le sens a
 évolué de "rentrer en seconde mi-temps pour découper les jambes du meilleur
-jouer adverse par un tacle assassin" en "[mettre en
-lambeau->http://fr.wiktionary.org/wiki/lac%C3%A9rer)".
+jouer adverse par un tacle assassin" en
+"[mettre en lambeau](http://fr.wiktionary.org/wiki/lac%C3%A9rer)".

--- a/2013/2013-02-01-alou-diarra-dit-oui-a-rennes.md
+++ b/2013/2013-02-01-alou-diarra-dit-oui-a-rennes.md
@@ -9,7 +9,8 @@ date: 2013-02-01 12:00:00 +0100
 ---
 
 Dead Rooster soutient le mariage pour tous mais quel dommage que, comme le titre
-l'Equipe, [Alou Diarra ait pu dire oui à
-Rennes](http://www.lequipe.fr/Football/Actualites/A-diarra-a-dit-oui-a-rennes/346698#xtor=RSS-1]
-alors qu'en son temps, [Daniel Prévost n'avait pu dire oui à
-Montcuq->http://youtu.be/iX9SPTSY1iU). Le monde va mal !
+l'Equipe,
+[Alou Diarra ait pu dire oui à Rennes](http://www.lequipe.fr/Football/Actualites/A-diarra-a-dit-oui-a-rennes/346698#xtor=RSS-1)
+alors qu'en son temps,
+[Daniel Prévost n'avait pu dire oui à Montcuq](http://youtu.be/iX9SPTSY1iU). Le
+monde va mal !

--- a/2013/2013-02-14-kurt-vile-wakin-on-a-pretty-day.md
+++ b/2013/2013-02-14-kurt-vile-wakin-on-a-pretty-day.md
@@ -8,8 +8,8 @@ date: "2013-02-14 10:00:00 +0100"
 ---
 
 Le prochain LP de Kurt Vile, _Wakin on a Pretty Daze_, sortira le 9 avril. Le
-précédent, _Smoke Ring For My Halo_, [avait été un de nos chouchous](992] et
-vous pouvez réécouter Jesus Fever [ici->822).
+précédent, _Smoke Ring For My Halo_, [avait été un de nos chouchous](992) et
+vous pouvez réécouter Jesus Fever [ici](822).
 
 {% youtube bd0K76H7sU8 %}
 

--- a/2013/2013-02-15-beck-sound-and-vision.md
+++ b/2013/2013-02-15-beck-sound-and-vision.md
@@ -12,8 +12,8 @@ musiciens. Si les 3 premières minutes vous saoulent, c'est sans doute normal,
 mais celles qui suivent sont top !
 
 Si vous aimez les reprises de Beck, vous avez aussi celle de _Sunday Morning_
-[ici](1178]. Et si vous préférez les originales, _Where It's At_, une des
-chansons les plus cool de l'histoire, est [là->991).
+[ici](1178). Et si vous préférez les originales, _Where It's At_, une des
+chansons les plus cool de l'histoire, est [là](991).
 
 {% youtube QnOmrDzRrGQ %}
 

--- a/2013/2013-02-18-the-strokes-all-the-time.md
+++ b/2013/2013-02-18-the-strokes-all-the-time.md
@@ -16,6 +16,6 @@ de l'efficace.
 {% youtube TJC8zeu3MHk %}
 
 (via
-[Pitchfork](http://pitchfork.com/news/49544-listen-to-the-new-strokes-single-all-the-time/]
+[Pitchfork](http://pitchfork.com/news/49544-listen-to-the-new-strokes-single-all-the-time/)
 et
-[Stereogum->http://feedproxy.google.com/~r/stereogum/cBYa/~3/AXBHXtW-Gms/story01.htm))
+[Stereogum](http://feedproxy.google.com/~r/stereogum/cBYa/~3/AXBHXtW-Gms/story01.htm))

--- a/2013/2013-02-20-british-sea-power-machineries-of-joy.md
+++ b/2013/2013-02-20-british-sea-power-machineries-of-joy.md
@@ -14,7 +14,7 @@ du même nom en teaser.
 {% youtube 9ZXqDholIzg %}
 
 N'hésitez pas à réécouter leur LP précédent, _Valhalla Dancehall_, (et lire
-[notre petit commentaire à son sujet](961]) pendant ce temps-là, ou réécouter
-_Zeus_ [ici->709).
+[notre petit commentaire à son sujet](961)) pendant ce temps-là, ou réécouter
+_Zeus_ [ici](709).
 
 (via [le site officiel du groupe](http://www.britishseapower.co.uk/))

--- a/2013/2013-03-11-beach-house-wishes.md
+++ b/2013/2013-03-11-beach-house-wishes.md
@@ -12,7 +12,7 @@ spectacle offert par Beach House à la mi-temps d'un match de… quidditch ?
 
 {% youtube OS6duOoxctw %}
 
-Revoir [*Wild*](1157], [*White Moon*->682], ou [réécouter leur session
+Revoir [_Wild_](1157), [*White Moon*](682], ou [réécouter leur session
 Daytrotter->br126) (où l'on peut entendre _Used To Be_, titre du groupe pour
 lequel on a un gros faible).
 

--- a/2013/2013-03-11-beach-house-wishes.md
+++ b/2013/2013-03-11-beach-house-wishes.md
@@ -12,7 +12,7 @@ spectacle offert par Beach House à la mi-temps d'un match de… quidditch ?
 
 {% youtube OS6duOoxctw %}
 
-Revoir [_Wild_](1157), [*White Moon*](682], ou [réécouter leur session
+Revoir [_Wild_](1157), [*White Moon*](682), ou [réécouter leur session
 Daytrotter->br126) (où l'on peut entendre _Used To Be_, titre du groupe pour
 lequel on a un gros faible).
 

--- a/2013/2013-03-11-beach-house-wishes.md
+++ b/2013/2013-03-11-beach-house-wishes.md
@@ -12,9 +12,9 @@ spectacle offert par Beach House à la mi-temps d'un match de… quidditch ?
 
 {% youtube OS6duOoxctw %}
 
-Revoir [_Wild_](1157), [*White Moon*](682), ou [réécouter leur session
-Daytrotter->br126) (où l'on peut entendre _Used To Be_, titre du groupe pour
-lequel on a un gros faible).
+Revoir [_Wild_](1157), [_White Moon_](682), ou
+[réécouter leur session Daytrotter](br126) (où l'on peut entendre _Used To Be_,
+titre du groupe pour lequel on a un gros faible).
 
 (via
 [Pitchfork](http://pitchfork.com/news/49829-watch-the-surreal-beach-house-video-for-wishes-directed-by-eric-wareheim-and-starring-ray-wise/))

--- a/2013/2013-03-12-smith-westerns-varsity.md
+++ b/2013/2013-03-12-smith-westerns-varsity.md
@@ -19,6 +19,6 @@ UPDATE : la vidéo est là.
 Pareil que pour The National [hier](1227) : "Vivement l'album !"
 
 (via
-[Pitchfork](http://pitchfork.com/news/49781-smith-westerns-announce-new-album-soft-will-share-new-track-varsity/]
+[Pitchfork](http://pitchfork.com/news/49781-smith-westerns-announce-new-album-soft-will-share-new-track-varsity/)
 et
-[Pitchfork->http://pitchfork.com/news/50653-watch-smith-westerns-varsity-video/))
+[Pitchfork](http://pitchfork.com/news/50653-watch-smith-westerns-varsity-video/))

--- a/2013/2013-03-21-django-django-wor.md
+++ b/2013/2013-03-21-django-django-wor.md
@@ -8,9 +8,9 @@ date: "2013-03-21 11:15:28 +0100"
 ---
 
 On n'a pas beaucoup parlé de Django Django ici, mais les auteurs de
-[*Default*](http://open.spotify.com/track/1i3nx7UvC1dXiBRDFBORr4], titre le plus
+[_Default_](http://open.spotify.com/track/1i3nx7UvC1dXiBRDFBORr4), titre le plus
 "génial et insupportable" à la fois depuis le
-[_Conquest_->http://open.spotify.com/track/0LVRIyo9rj7oSrGu1z150w) des White
+[_Conquest_](http://open.spotify.com/track/0LVRIyo9rj7oSrGu1z150w) des White
 Stripes le mériteraient pourtant.
 
 Allez, mieux vaut tard que jamais :

--- a/2013/2013-03-27-the-computers-love-triangles-hate-squares.md
+++ b/2013/2013-03-27-the-computers-love-triangles-hate-squares.md
@@ -13,5 +13,5 @@ Cash n'était visiblement pas fait pour vendre des aspirateurs.
 
 {% youtube 5bdaVOAFKxg %}
 
-(via [One Little Indian](http://www.indian.co.uk] et [la page Facebook de la
-planète Mars->http://www.facebook.com/pages/Plan%C3%A8te-Mars/52247846225))
+(via [One Little Indian](http://www.indian.co.uk) et
+[la page Facebook de la planète Mars](http://www.facebook.com/pages/Plan%C3%A8te-Mars/52247846225))

--- a/2013/2013-03-28-sonny-the-sunsets-dark-corners.md
+++ b/2013/2013-03-28-sonny-the-sunsets-dark-corners.md
@@ -12,8 +12,8 @@ oreilles.
 
 <iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=http%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F83836899"></iframe>
 
-N'oubliez pas de réécouter leur excellente reprise d'[*Imagine*](1195] ou leur
-hit [_I Wanna Do It_->827).
+N'oubliez pas de réécouter leur excellente reprise d'[_Imagine_](1195) ou leur
+hit [_I Wanna Do It_](827).
 
 (via
 [Stereogum](http://stereogum.com/1293871/sonny-and-the-sunsets-dark-corners/mp3s/))

--- a/2013/2013-04-02-primal-scream-it-s-alright-it-s-ok.md
+++ b/2013/2013-04-02-primal-scream-it-s-alright-it-s-ok.md
@@ -17,6 +17,6 @@ mi-mai.
 {% youtube Ty-IJ3qz-GE %}
 
 (via
-[Telerama](http://www.telerama.fr/musique/it-s-alright-it-s-ok-un-nouveau-titre-de-primal-scream,95021.php]
+[Telerama](http://www.telerama.fr/musique/it-s-alright-it-s-ok-un-nouveau-titre-de-primal-scream,95021.php)
 et
-[Stereogum->http://stereogum.com/1309601/primal-scream-its-alright-its-ok-video/video/))
+[Stereogum](http://stereogum.com/1309601/primal-scream-its-alright-its-ok-video/video/))

--- a/2013/2013-04-03-bleeeding-rainbow-oblivion.md
+++ b/2013/2013-04-03-bleeeding-rainbow-oblivion.md
@@ -13,7 +13,7 @@ des sessions de l'album. Toujours aussi bon.
 <iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=http%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F84847643"></iframe>
 
 Plein d'autres chansons du groupe sont à écouter (certaines sous leur ancien
-nom, [Reading Rainbow](728]) : [*Drift Away*->1133], [*Dead End*->910] ou
+nom, [Reading Rainbow](728)) : [*Drift Away*](1133], [*Dead End*->910] ou
 [_Wasting Time_->712).
 
 (via [Stereogum](http://stereogum.com/1300722/bleeding-rainbow-oblivion/mp3s/))

--- a/2013/2013-04-03-bleeeding-rainbow-oblivion.md
+++ b/2013/2013-04-03-bleeeding-rainbow-oblivion.md
@@ -13,7 +13,7 @@ des sessions de l'album. Toujours aussi bon.
 <iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=http%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F84847643"></iframe>
 
 Plein d'autres chansons du groupe sont à écouter (certaines sous leur ancien
-nom, [Reading Rainbow](728)) : [*Drift Away*](1133), [*Dead End*->910] ou
-[_Wasting Time_->712).
+nom, [Reading Rainbow](728)) : [_Drift Away_](1133), [_Dead End_](910) ou
+[_Wasting Time_](712).
 
 (via [Stereogum](http://stereogum.com/1300722/bleeding-rainbow-oblivion/mp3s/))

--- a/2013/2013-04-03-bleeeding-rainbow-oblivion.md
+++ b/2013/2013-04-03-bleeeding-rainbow-oblivion.md
@@ -13,7 +13,7 @@ des sessions de l'album. Toujours aussi bon.
 <iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=http%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F84847643"></iframe>
 
 Plein d'autres chansons du groupe sont à écouter (certaines sous leur ancien
-nom, [Reading Rainbow](728)) : [*Drift Away*](1133], [*Dead End*->910] ou
+nom, [Reading Rainbow](728)) : [*Drift Away*](1133), [*Dead End*->910] ou
 [_Wasting Time_->712).
 
 (via [Stereogum](http://stereogum.com/1300722/bleeding-rainbow-oblivion/mp3s/))

--- a/2013/2013-04-08-the-strokes-fast-animals.md
+++ b/2013/2013-04-08-the-strokes-fast-animals.md
@@ -19,7 +19,7 @@ publieront à l'occasion du Record Store Day le 20 avril.
 
 {% youtube zMHEvVyb2Pg %}
 
-N'hésitez pas à réécouter [*All The Time*](1179], qui sera la face A du même
-single, ou [la reprise de _Just What I Needed_ avec Jarvis Cocker->899).
+N'hésitez pas à réécouter [_All The Time_](1179), qui sera la face A du même
+single, ou [la reprise de _Just What I Needed_ avec Jarvis Cocker](899).
 
 (via [Stereogum](http://stereogum.com/1297372/the-strokes-fast-animals/mp3s/))

--- a/2013/2013-04-18-black-rebel-motorcycle-club-let-the-day-begin.md
+++ b/2013/2013-04-18-black-rebel-motorcycle-club-let-the-day-begin.md
@@ -22,7 +22,7 @@ Feast_ est sorti le mois dernier.
 
 {% youtube mmtQwtcaqLM %}
 
-Il y a 2 ans, on écoutait [*Berlin*](783]. Auparavant, on écoutait [leur reprise
-de _Dirty Old Town_->709).
+Il y a 2 ans, on écoutait [_Berlin_](783). Auparavant, on écoutait
+[leur reprise de _Dirty Old Town_](709).
 
 via [leur site officiel](http://blackrebelmotorcycleclub.com/)

--- a/2013/2013-04-29-dale-earnhardt-jr-jr-hiding.md
+++ b/2013/2013-04-29-dale-earnhardt-jr-jr-hiding.md
@@ -12,8 +12,8 @@ dernière un EP qui s'appelle _Patterns_.
 
 <iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=http%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F87131673"></iframe>
 
-Vous pouvez [revoir le clip TTM de *Simple Girl*](912] ou [leur reprise de _God
-Only Knows_->709) qui est, rappelons-le, le meilleur titre de l'histoire selon
-Paul McCartney. C'est pas rien.
+Vous pouvez [revoir le clip TTM de _Simple Girl_](912) ou
+[leur reprise de _God Only Knows_](709) qui est, rappelons-le, le meilleur titre
+de l'histoire selon Paul McCartney. C'est pas rien.
 
 via [Stereogum](http://stereogum.com/1318811/dale-earnhardt-jr-jr-hiding/news/)

--- a/2013/2013-05-15-jay-z-mcfly.md
+++ b/2013/2013-05-15-jay-z-mcfly.md
@@ -8,9 +8,10 @@ cover: jay-z-vintage-sosie.jpg
 date: 2013-05-15 12:11:43 +0200
 ---
 
-Le NME révèle enfin que [Jay-Z voyage dans le
-temps](http://www.nme.com/news/jay-z/70294]. Mais il n'est pas le seul ! Trop
-peu de gens n'osent parler de George McFly, héros de [la féérie dansante des
-sirènes->http://backtothefuturecollection.over-blog.com/article-invitations-a-la-feerie-dansantes-des-sirenes-1955-107765889.html]
+Le NME révèle enfin que
+[Jay-Z voyage dans le temps](http://www.nme.com/news/jay-z/70294). Mais il n'est
+pas le seul ! Trop peu de gens n'osent parler de George McFly, héros de [la
+féérie dansante des
+sirènes](http://backtothefuturecollection.over-blog.com/article-invitations-a-la-feerie-dansantes-des-sirenes-1955-107765889.html]
 du 12 novembre 1955 à Hill Valley, qui est en 2013 [l'avant-centre du Bayern
 Munich->http://cheezburger.com/6068865792). Le monde va mal !

--- a/2013/2013-05-15-jay-z-mcfly.md
+++ b/2013/2013-05-15-jay-z-mcfly.md
@@ -12,6 +12,6 @@ Le NME révèle enfin que
 [Jay-Z voyage dans le temps](http://www.nme.com/news/jay-z/70294). Mais il n'est
 pas le seul ! Trop peu de gens n'osent parler de George McFly, héros de [la
 féérie dansante des
-sirènes](http://backtothefuturecollection.over-blog.com/article-invitations-a-la-feerie-dansantes-des-sirenes-1955-107765889.html]
+sirènes](http://backtothefuturecollection.over-blog.com/article-invitations-a-la-feerie-dansantes-des-sirenes-1955-107765889.html)
 du 12 novembre 1955 à Hill Valley, qui est en 2013 [l'avant-centre du Bayern
 Munich->http://cheezburger.com/6068865792). Le monde va mal !

--- a/2013/2013-05-15-jay-z-mcfly.md
+++ b/2013/2013-05-15-jay-z-mcfly.md
@@ -10,8 +10,8 @@ date: 2013-05-15 12:11:43 +0200
 
 Le NME révèle enfin que
 [Jay-Z voyage dans le temps](http://www.nme.com/news/jay-z/70294). Mais il n'est
-pas le seul ! Trop peu de gens n'osent parler de George McFly, héros de [la
-féérie dansante des
-sirènes](http://backtothefuturecollection.over-blog.com/article-invitations-a-la-feerie-dansantes-des-sirenes-1955-107765889.html)
-du 12 novembre 1955 à Hill Valley, qui est en 2013 [l'avant-centre du Bayern
-Munich->http://cheezburger.com/6068865792). Le monde va mal !
+pas le seul ! Trop peu de gens n'osent parler de George McFly, héros de
+[la féérie dansante des sirènes](http://backtothefuturecollection.over-blog.com/article-invitations-a-la-feerie-dansantes-des-sirenes-1955-107765889.html)
+du 12 novembre 1955 à Hill Valley, qui est en 2013
+[l'avant-centre du Bayern Munich](http://cheezburger.com/6068865792). Le monde
+va mal !

--- a/2013/2013-05-17-mikal-cronin-change.md
+++ b/2013/2013-05-17-mikal-cronin-change.md
@@ -15,6 +15,6 @@ _MCII_, chaudement recommandé.
 Cronin sera de passage en France en août.
 
 (via
-[Pitchfork](http://pitchfork.com/news/50748-watch-mikal-cronin-play-an-eerie-house-party-in-the-change-video/]
-et [Merge
-Records->http://www.mergerecords.com/blog/2013/05/mikal-cronin-premieres-new-video-for-change-extends-european-tour/))
+[Pitchfork](http://pitchfork.com/news/50748-watch-mikal-cronin-play-an-eerie-house-party-in-the-change-video/)
+et
+[Merge Records](http://www.mergerecords.com/blog/2013/05/mikal-cronin-premieres-new-video-for-change-extends-european-tour/))

--- a/2013/2013-06-19-sonny-the-sunsets-green-blood.md
+++ b/2013/2013-06-19-sonny-the-sunsets-green-blood.md
@@ -12,7 +12,7 @@ remédions à ça !!!
 
 {% youtube 5i5zO7aXiFA %}
 
-Complète ta collection avec [_Palmreader_](1238), [*Dark Corners*](1205] ou le
+Complète ta collection avec [_Palmreader_](1238), [*Dark Corners*](1205) ou le
 plus ancien [*I Wanna Do It*->827] voire leur reprise d'[_Imagine_->1195).
 
 (via

--- a/2013/2013-06-19-sonny-the-sunsets-green-blood.md
+++ b/2013/2013-06-19-sonny-the-sunsets-green-blood.md
@@ -12,8 +12,8 @@ remédions à ça !!!
 
 {% youtube 5i5zO7aXiFA %}
 
-Complète ta collection avec [_Palmreader_](1238), [*Dark Corners*](1205) ou le
-plus ancien [*I Wanna Do It*->827] voire leur reprise d'[_Imagine_->1195).
+Complète ta collection avec [_Palmreader_](1238), [_Dark Corners_](1205) ou le
+plus ancien [_I Wanna Do It_](827) voire leur reprise d'[_Imagine_](1195).
 
 (via
 [Stereogum](http://www.stereogum.com/1384481/sonny-the-sunsets-green-blood-video/video/))

--- a/2013/2013-06-19-sonny-the-sunsets-green-blood.md
+++ b/2013/2013-06-19-sonny-the-sunsets-green-blood.md
@@ -12,7 +12,7 @@ remédions à ça !!!
 
 {% youtube 5i5zO7aXiFA %}
 
-Complète ta collection avec [*Palmreader*](1238], [*Dark Corners*->1205] ou le
+Complète ta collection avec [_Palmreader_](1238), [*Dark Corners*](1205] ou le
 plus ancien [*I Wanna Do It*->827] voire leur reprise d'[_Imagine_->1195).
 
 (via

--- a/2013/2013-06-21-arctic-monkeys-do-i-wanna-know.md
+++ b/2013/2013-06-21-arctic-monkeys-do-i-wanna-know.md
@@ -12,9 +12,9 @@ Les Arctic Monkeys annonce leur retour prochain avec _Do I Wanna Know?_
 {% youtube bpOSxM0rNPM %}
 
 Rappelez-vous également des anciens titres aux noms rigolos des singes de
-l'arctique : [_The Hellcat Spangled Shalalala_](872) ou [*Don’t Sit Down ‘Cause
-I’ve Moved Your Chair*](823). Voire ce qu'Alex Turner a fait de meilleur à mes
-yeux, la B.O. de [_Submarine_->879).
+l'arctique : [_The Hellcat Spangled Shalalala_](872) ou
+[_Don’t Sit Down ‘Cause I’ve Moved Your Chair_](823). Voire ce qu'Alex Turner a
+fait de meilleur à mes yeux, la B.O. de [_Submarine_](879).
 
 (via
 [Pitchfork](http://pitchfork.com/news/51224-listen-new-arctic-monkeys-do-i-wanna-know/))

--- a/2013/2013-06-21-arctic-monkeys-do-i-wanna-know.md
+++ b/2013/2013-06-21-arctic-monkeys-do-i-wanna-know.md
@@ -12,8 +12,8 @@ Les Arctic Monkeys annonce leur retour prochain avec _Do I Wanna Know?_
 {% youtube bpOSxM0rNPM %}
 
 Rappelez-vous également des anciens titres aux noms rigolos des singes de
-l'arctique : [*The Hellcat Spangled Shalalala*](872] ou [*Don’t Sit Down ‘Cause
-I’ve Moved Your Chair*->823]. Voire ce qu'Alex Turner a fait de meilleur à mes
+l'arctique : [_The Hellcat Spangled Shalalala_](872) ou [*Don’t Sit Down ‘Cause
+I’ve Moved Your Chair*](823]. Voire ce qu'Alex Turner a fait de meilleur à mes
 yeux, la B.O. de [_Submarine_->879).
 
 (via

--- a/2013/2013-06-21-arctic-monkeys-do-i-wanna-know.md
+++ b/2013/2013-06-21-arctic-monkeys-do-i-wanna-know.md
@@ -13,7 +13,7 @@ Les Arctic Monkeys annonce leur retour prochain avec _Do I Wanna Know?_
 
 Rappelez-vous également des anciens titres aux noms rigolos des singes de
 l'arctique : [_The Hellcat Spangled Shalalala_](872) ou [*Don’t Sit Down ‘Cause
-I’ve Moved Your Chair*](823]. Voire ce qu'Alex Turner a fait de meilleur à mes
+I’ve Moved Your Chair*](823). Voire ce qu'Alex Turner a fait de meilleur à mes
 yeux, la B.O. de [_Submarine_->879).
 
 (via

--- a/2013/2013-06-26-black-rebel-motorcycle-club-hate-the-taste.md
+++ b/2013/2013-06-26-black-rebel-motorcycle-club-hate-the-taste.md
@@ -14,4 +14,4 @@ album _Specter at the Feast_, sorti en mars.
 
 Rappelons encore une fois que ce groupe sous-côté est l'un de nos chouchous
 comme le prouvent la présence parmi ces pages de [_Let The Day Begin_](1221),
-[*Berlin*](783) ou [leur reprise de _Dirty Old Town_->709).
+[_Berlin_](783) ou [leur reprise de _Dirty Old Town_](709).

--- a/2013/2013-06-26-black-rebel-motorcycle-club-hate-the-taste.md
+++ b/2013/2013-06-26-black-rebel-motorcycle-club-hate-the-taste.md
@@ -13,5 +13,5 @@ album _Specter at the Feast_, sorti en mars.
 {% youtube iaZc0ITpnQ8 %}
 
 Rappelons encore une fois que ce groupe sous-côté est l'un de nos chouchous
-comme le prouvent la présence parmi ces pages de [*Let The Day Begin*](1221],
-[*Berlin*->783] ou [leur reprise de _Dirty Old Town_->709).
+comme le prouvent la présence parmi ces pages de [_Let The Day Begin_](1221),
+[*Berlin*](783] ou [leur reprise de _Dirty Old Town_->709).

--- a/2013/2013-06-26-black-rebel-motorcycle-club-hate-the-taste.md
+++ b/2013/2013-06-26-black-rebel-motorcycle-club-hate-the-taste.md
@@ -14,4 +14,4 @@ album _Specter at the Feast_, sorti en mars.
 
 Rappelons encore une fois que ce groupe sous-côté est l'un de nos chouchous
 comme le prouvent la présence parmi ces pages de [_Let The Day Begin_](1221),
-[*Berlin*](783] ou [leur reprise de _Dirty Old Town_->709).
+[*Berlin*](783) ou [leur reprise de _Dirty Old Town_->709).


### PR DESCRIPTION
This PR removes all occurrences of SPIP-style links that were left in the articles.

It was a mix of massive regular expressions "find & replace" but also sometimes manual updates.