### PR TITLE
Remove links to iguessimfloating.net

### DIFF
--- a/2010/2010-07-28-election-du-meilleur-nom-de-groupe-2010.md
+++ b/2010/2010-07-28-election-du-meilleur-nom-de-groupe-2010.md
@@ -13,46 +13,27 @@ categories:
   - Catégories
 tags:
   - Band Naming Award
-comments:
-  - author: Dirty Henry
-    author_email: dirtyhenry@gmail.com
-    date: 2010-08-30 15:06:05 +0200
-    title: Election du meilleur nom de groupe 2010 !
-    content:
-      "Nouveau candidat : Com Truise\r\n(cf.
-      http://stereogum.com/447862/com-truise-sundriped/mp3s/)"
-  - author: Dirty Henry
-    author_email: dirtyhenry@gmail.com
-    date: 2010-09-13 16:10:24 +0200
-    title: Election du meilleur nom de groupe 2010 !
-    content:
-      "Dumbo Gets
-      Mad\r\nhttp://www.iguessimfloating.net/2010/09/mp3-dumbo-gets-mad-plumy-tale.html"
-  - author: Dirty Henry
-    author_email: dirtyhenry@gmail.com
-    date: 2010-09-17 10:44:08 +0200
-    title: Election du meilleur nom de groupe 2010 !
-    content:
-      "Someone Still Loves You Boris Yeltsin
-      \r\nhttp://pitchfork.com/reviews/albums/14554-let-it-sway/\r\n\r\nDelorean\r\n\r\nDes
-      candidats sérieux."
-  - author: Dirty Henry
-    author_email: dirtyhenry@gmail.com
-    date: 2010-09-17 10:44:32 +0200
-    title: Election du meilleur nom de groupe 2010 !
-    content: Sheetah et les Weissmuller (of course)
 ---
 
-Venant de tomber sur
-[ce post](http://iguessimfloating.blogspot.com/2010/07/video-phoenix-foundation-pot.html),
-je m'aperçois qu'il manque une récompense dans le monde de la musique.
-
-Toutes ces cérémonies négligent un art subtil, qui préfigure l'avenir d'un
-groupe, même avant son premier concert, sa première répétition ou quoi que ce
-soit d'autre : l'art du **band-naming** !
+Je m'aperçois qu'il manque une récompense dans le monde de la musique. Toutes
+ces cérémonies négligent un art subtil, qui préfigure l'avenir d'un groupe, même
+avant son premier concert, sa première répétition ou quoi que ce soit d'autre :
+l'art du **band-naming** !
 
 Je lance donc le processus de sélection des nommés pour l'édition 2010 :
 
-- The Phoenix Fundation
+- [The Phoenix Fundation][1]
+- [Com Truise][2]
+- [Dumbo Gets Mad][3]
+- [Someone Still Loves You Boris Yeltsin][4]
+- [Delorean][5]
+- [Sheetah et les Weissmuller][6]
 
 N'hésitez pas à proposer les vôtres dans les commentaires.
+
+[1]: https://en.wikipedia.org/wiki/The_Phoenix_Foundation
+[2]: https://fr.wikipedia.org/wiki/Com_Truise
+[3]: https://en.wikipedia.org/wiki/Dumbo_Gets_Mad
+[4]: https://en.wikipedia.org/wiki/Someone_Still_Loves_You_Boris_Yeltsin
+[5]: https://fr.wikipedia.org/wiki/Delorean_(groupe)
+[6]: https://www.facebook.com/SheetahetlesWeissmuller

--- a/2010/2010-08-27-magic-kids-superball.md
+++ b/2010/2010-08-27-magic-kids-superball.md
@@ -15,10 +15,9 @@ tags:
   - Single
 ---
 
+{% youtube inp3Dh1zib8 %}
+
 Le groupe de Memphis **Magic Kids** nous invite à imaginer qu'on est en
 Californie dans les années 60.
 
-{% youtube inp3Dh1zib8 %}
-
-(via
-[iguessimfloating.net](http://www.iguessimfloating.net/2010/08/video-magic-kids-superball.html))
+(via feu iguessimfloating.net)

--- a/2010/2010-09-02-jolies-pochettes-restons-en-la.md
+++ b/2010/2010-09-02-jolies-pochettes-restons-en-la.md
@@ -27,7 +27,7 @@ Beat Connection vient de diffuser un EP gratuit sur bandcamp.
 <img367|center>
 
 Les gens de I Guess I'm Floating sont d'accord sur la qualité de la pochette… et
-[partagent les doutes sur la musique](http://www.iguessimfloating.net/2010/08/mpfree-warm-waves-lifted-ep.html).
+partagent les doutes sur la musique.
 
 ## Pony Club
 

--- a/2010/2010-09-13-compile-mp3-du-net-01.md
+++ b/2010/2010-09-13-compile-mp3-du-net-01.md
@@ -38,8 +38,8 @@ Maroquinerie, à Paris, le 4 octobre.
 </div></li>
 
 <li><div class="polaroid">
-[<img372> Family Trees
-*Dream Talkin*](http://iguessimfloating.blogspot.com/2010/07/mp3-family-trees-dream-talkin.html)
+<img372> Family Trees
+*Dream Talkin*
 </div></li>
 
 <li><div class="polaroid">
@@ -58,8 +58,8 @@ Maroquinerie, à Paris, le 4 octobre.
 </div></li>
 
 <li><div class="polaroid">
-[<img376> Levek
-*Second Second*](http://iguessimfloating.blogspot.com/2010/08/mp3-new-levek-second-second-viernes.html)
+<img376> Levek
+*Second Second*
 </div></li>
 
 <li><div class="polaroid">

--- a/2010/2010-09-20-compile-mp3-du-net-02.md
+++ b/2010/2010-09-20-compile-mp3-du-net-02.md
@@ -27,8 +27,8 @@ Au programme cette semaine, **The Shins** reprennent un titre du groupe Squeeze,
 </div></li>
 
 <li><div class="polaroid">
-[<img379> Strange Shapes
-*I Found A Rock*](http://iguessimfloating.blogspot.com/2010/07/mp3-strange-shapes-i-found-rock.html)
+<img379> Strange Shapes
+*I Found A Rock*
 </div></li>
 
 <li><div class="polaroid">
@@ -42,8 +42,8 @@ Au programme cette semaine, **The Shins** reprennent un titre du groupe Squeeze,
 </div></li>
 
 <li><div class="polaroid">
-[<img380> Sri Aurobindo
-*Soul Vibrations of Man*](http://iguessimfloating.blogspot.com/2010/07/mp3-sri-aurobindo-soul-vibrations-of.html)
+<img380> Sri Aurobindo
+*Soul Vibrations of Man*
 </div></li>
 
 <li><div class="polaroid">
@@ -52,8 +52,8 @@ Au programme cette semaine, **The Shins** reprennent un titre du groupe Squeeze,
 </div></li>
 
 <li><div class="polaroid">
-[<img382> Foxes In Fiction
-*Flashing Lights Have Ended Now*](http://www.iguessimfloating.net/2010/07/mp3-new-foxes-in-fiction-flashing.html)
+<img382> Foxes In Fiction
+*Flashing Lights Have Ended Now*
 </div></li>
 
 <li><div class="polaroid">
@@ -62,8 +62,8 @@ Au programme cette semaine, **The Shins** reprennent un titre du groupe Squeeze,
 </div></li>
 
 <li><div class="polaroid">
-[<img386>Pepper Rabbit
-*Older Brother*](http://www.iguessimfloating.net/2010/08/mp3-pepper-rabbit-older-brother.html)
+<img386>Pepper Rabbit
+*Older Brother*
 </div></li>
 
 </ul>

--- a/2010/2010-09-27-compile-mp3-du-net-03.md
+++ b/2010/2010-09-27-compile-mp3-du-net-03.md
@@ -25,8 +25,8 @@ particulièrement à découvrir les excellents **Guards** et **The Fresh & Onlys
 <ul class="polaroids">
 
 <li><div class="polaroid">
-[<img390>Guards
-*Long Time*](http://www.iguessimfloating.net/2010/07/mpfree-guards-st-debut-ep-feat-cults.html)
+<img390>Guards
+*Long Time*
 </div></li>
 
 <li><div class="polaroid">
@@ -40,8 +40,8 @@ particulièrement à découvrir les excellents **Guards** et **The Fresh & Onlys
 </div></li>
 
 <li><div class="polaroid">
-[<img393>Parenthetical Girls
-*Young Throats*](http://www.iguessimfloating.net/2010/08/mp3-new-parenthetical-girls-young-throats.html)
+<img393>Parenthetical Girls
+*Young Throats*
 </div></li>
 
 <li><div class="polaroid">
@@ -50,8 +50,8 @@ particulièrement à découvrir les excellents **Guards** et **The Fresh & Onlys
 </div></li>
 
 <li><div class="polaroid">
-[<img396>Telenovelas
-*One and Only*](http://www.iguessimfloating.net/2010/08/mp3-telenovelas-one-and-only.html)
+<img396>Telenovelas
+*One and Only*
 </div></li>
 
 <li><div class="polaroid">

--- a/2010/2010-10-04-compile-mp3-du-net-04.md
+++ b/2010/2010-10-04-compile-mp3-du-net-04.md
@@ -37,8 +37,8 @@ Only Knows_, des Beach Boys.
 <li><div class="polaroid">[<img404>Shannon Wright
 *Commoner’s Saint*](http://www.popnews.com/news/6172/un-mp3-de-shannon-wright-en-exclusivite/)</div></li>
 
-<li><div class="polaroid">[<img401>Computer Magic
-*About You*](http://www.iguessimfloating.net/2010/09/mp3-new-computer-magic-about-you.html)</div></li>
+<li><div class="polaroid"><img401>Computer Magic
+*About You*</div></li>
 
 <li><div class="polaroid">[<img407>Cheyenne Marie Mize
 *Beautiful Dreamer*](http://www.bonpourlesoreilles.net/musique/2010/08/old-western.html)</div></li>

--- a/2010/2010-10-11-compile-mp3-du-net-05.md
+++ b/2010/2010-10-11-compile-mp3-du-net-05.md
@@ -24,14 +24,14 @@ et fermer la compile avec une reprise de Katy Perry.
 
 <ul class="polaroids">
 
-<li><div class=polaroid>[<img410>Foxes In Fiction
-*Bathurst*](http://www.iguessimfloating.net/2010/09/mp3-new-foxes-in-fiction-bathurst.html)</div></li>
-<li><div class=polaroid>[<img411>Mean Wind
-*Yr Swword*](http://www.iguessimfloating.net/2010/09/mpfree-mean-windss-what-happens-in-hingham-ep.html)</div></li>
+<li><div class=polaroid><img410>Foxes In Fiction
+*Bathurst*</div></li>
+<li><div class=polaroid><img411>Mean Wind
+*Yr Swword*</div></li>
 <li><div class=polaroid>[<img412>Lower Dens
 *Blue And Silver*](http://stereogum.com/522201/lower-dens-blue-and-silver/mp3s/)</div></li>
-<li><div class=polaroid>[<img413>Seamonster
-*Oh Appalachia*](http://www.iguessimfloating.net/2010/09/mpfree-seamonsters-two-birds-ep.html)</div></li>
+<li><div class=polaroid><img413>Seamonster
+*Oh Appalachia*</div></li>
 <li><div class=polaroid>[<img414>Sharon Van Etten
 *Don’t Do It*](http://stereogum.com/503982/sharon-van-etten-dont-do-it-stereogum-premiere/mp3s/)</div></li>
 <li><div class=polaroid>[<img415>Chapter
@@ -40,8 +40,8 @@ et fermer la compile avec une reprise de Katy Perry.
 *Hamilton Road*](http://stereogum.com/463342/ducktails-hamilton-road/mp3s/)</div></li>
 <li><div class=polaroid>[<img417>Reading Rainbow
 *Wasting Time*](http://stereogum.com/506002/reading-rainbow-wasting-time/mp3s/)</div></li>
-<li><div class=polaroid>[<img418>Foxes in Fiction & Weed
-*Teenage Dream (Katy Perry)*](http://www.iguessimfloating.net/2010/09/thursday-and-covers-2.html)</div></li>
+<li><div class=polaroid><img418>Foxes in Fiction & Weed
+*Teenage Dream (Katy Perry)*</div></li>
 
 </ul>
 

--- a/2010/2010-10-19-compile-mp3-du-net-06.md
+++ b/2010/2010-10-19-compile-mp3-du-net-06.md
@@ -28,8 +28,8 @@ de **Black Mountain** par **The Black Angels**.
 *Bummer Summer*](http://stereogum.com/447372/popo-bummer-summer/mp3s/)</div></li>
 <li><div class=polaroid>[<img431>Andrew Cedermark
 *Hard Livin'*](http://pitchfork.com/reviews/albums/14628-moon-deluxe/)</div></li>
-<li><div class=polaroid>[<img423>Dumbo Gets Mad
-*Plumy Tale*](http://www.iguessimfloating.net/2010/09/mp3-dumbo-gets-mad-plumy-tale.html)</div></li>
+<li><div class=polaroid><img423>Dumbo Gets Mad
+*Plumy Tale*</div></li>
 <li><div class=polaroid>[<img424>Women
 *Narrow With The Hall*](http://pitchfork.com/forkcast/14793-narrow-with-the-hall/)</div></li>
 <li><div class=polaroid>[<img426>The Black Angels

--- a/2010/2010-11-30-compile-mp3-du-net-08.md
+++ b/2010/2010-11-30-compile-mp3-du-net-08.md
@@ -30,8 +30,8 @@ Pavement est au programme.
 {Awake}](http://wearethenotes.bandcamp.com)</div></li>
 <li><div class=polaroid>[<img451>Mièle
 {La Chose}](http://soundcloud.com/humptydumptyrecords/miele-la-chose/comments)</div></li>
-<li><div class=polaroid>[<img452>Sweet Lights
-{Ballad of Kurt Vile #2}](http://www.iguessimfloating.net/2010/09/mp3-sweet-lights-ballad-of-kurt-vile-2.html)</div></li>
+<li><div class=polaroid><img452>Sweet Lights
+{Ballad of Kurt Vile #2}</div></li>
 <li><div class=polaroid>[<img453>Surfer Blood
 {Box Elder (Pavement)}](http://halfwayhousemusic.com/2010/10/11/halfway-house-sessions-surfer-blood/)</div></li>
 <li><div class=polaroid>[<img454>Phosphorescent

--- a/2010/2010-12-06-compile-mp3-du-net-08.md
+++ b/2010/2010-12-06-compile-mp3-du-net-08.md
@@ -36,8 +36,8 @@ A noter qu'une reprise de **Pavement** est au programme.
 *Awake*](http://wearethenotes.bandcamp.com)</div></li>
 <li><div class=polaroid>[<img451>Mièle
 *La Chose*](http://soundcloud.com/humptydumptyrecords/miele-la-chose/comments)</div></li>
-<li><div class=polaroid>[<img452>Sweet Lights
-*Ballad of Kurt Vile #2*](http://www.iguessimfloating.net/2010/09/mp3-sweet-lights-ballad-of-kurt-vile-2.html)</div></li>
+<li><div class=polaroid><img452>Sweet Lights
+*Ballad of Kurt Vile #2*</div></li>
 <li><div class=polaroid>[<img453>Surfer Blood
 *Box Elder (Pavement)*](http://halfwayhousemusic.com/2010/10/11/halfway-house-sessions-surfer-blood/)</div></li>
 <li><div class=polaroid>[<img454>Phosphorescent

--- a/2011/2011-01-11-top-musique-2010.md
+++ b/2011/2011-01-11-top-musique-2010.md
@@ -167,9 +167,8 @@ Pour se faire, j'ai repris les tops des sites suivants :
   papa, on y parle autant des nouveautés que de Bruce Sprinsteen et de Weezer
 - [Stereogum](http://stereogum.com/) : encore une source US, un peu plus
   défricheur dans l'âme mais assez similaire à Pitchfork malgré tout
-- [I Guess I'm Floating](http://www.iguessimfloating.net/) : mon blog US de
-  pré-hype préféré, ils ont leur petit réseau et on y trouve souvent de belles
-  pépites
+- I Guess I'm Floating : mon blog US de pré-hype préféré, ils ont leur petit
+  réseau et on y trouve souvent de belles pépites
 - [Les Inrocks](http://www.lesinrocks.com/) : la source française incontournable
 - [Ground Zero](http://www.groundzero.fr/) : un disquaire parisien
 - [Bon Pour les Oreilles](http://www.bonpourlesoreilles.net/) : un blog suisse

--- a/2011/2011-01-15-top-music-2010.md
+++ b/2011/2011-01-15-top-music-2010.md
@@ -125,9 +125,8 @@ I started with the top music of the following sites:
   as you can articles about Bruce Springsteen and Weezer
 - [Stereogum](http://stereogum.com/): also an American source, a bit more
   alternative in spirit, but pretty similar to Pitchfork
-- [I Guess I'm Floating](http://www.iguessimfloating.net/): my favorite US
-  “pre-hype” blog, they have their small network and they often discover really
-  interesting treats
+- I Guess I'm Floating: my favorite US “pre-hype” blog, they have their small
+  network and they often discover really interesting treats
 - [Les Inrocks](http://www.lesinrocks.com/): The essential French source
 - [Ground Zero](http://www.groundzero.fr/): a Parisian record shop
 - [Bon Pour les Oreilles](http://www.bonpourlesoreilles.net/): a Swiss Blog

--- a/2012/2012-01-18-top-musique-2011.md
+++ b/2012/2012-01-18-top-musique-2011.md
@@ -94,9 +94,8 @@ tous les sites qu'on aime bien :
   papa, on y parle autant des nouveautés que de Bruce Sprinsteen et de Weezer
 - [Stereogum](http://stereogum.com/) : encore une source US, un peu plus
   défricheur dans l'âme mais assez similaire à Pitchfork malgré tout
-- [I Guess I'm Floating](http://www.iguessimfloating.net/) : mon blog US de
-  pré-hype préféré, ils ont leur petit réseau et on y trouve souvent de belles
-  pépites
+- I Guess I'm Floating : mon blog US de pré-hype préféré, ils ont leur petit
+  réseau et on y trouve souvent de belles pépites
 - [Les Inrocks](http://www.lesinrocks.com/) : la source française incontournable
 - [Magic](http://www.magicrpm.com/) : un concurrent sérieux aux Inrocks
 - [Bon Pour les Oreilles](http://www.bonpourlesoreilles.net/) : un blog suisse

--- a/2012/2012-01-27-top-music-2011.md
+++ b/2012/2012-01-27-top-music-2011.md
@@ -53,9 +53,8 @@ lists" from our favorite music sites of the year!
   much new music as you can articles about Bruce Springsteen and Weezer
 - [Stereogum](http://stereogum.com/): Also an American source, a bit more
   alternative in spirit, but pretty similar to Pitchfork
-- [I Guess I'm Floating](http://www.iguessimfloating.net/): My favorite US
-  “pre-hype” blog, they have their small network and they often discover really
-  interesting treats
+- I Guess I'm Floating: My favorite US “pre-hype” blog, they have their small
+  network and they often discover really interesting treats
 - [Les Inrocks](http://www.lesinrocks.com/): The essential French source
 - [Magic](http://www.magicrpm.com/): An alternative French source that I like
   more and more

--- a/2013/2013-02-19-field-mouse-tomorrow-is-yesterday.md
+++ b/2013/2013-02-19-field-mouse-tomorrow-is-yesterday.md
@@ -7,11 +7,10 @@ wordpress_id: 1180
 date: "2013-02-19 10:00:00 +0100"
 ---
 
+{% soundcloud 78106313 %}
+
 Section "découverte 2013", on vous présente Field Mouse. Un duo qui vient de
 Brooklyn qui se qualifie de dream pop influencé par le shoegaze, l'indie, et la
 power pop. En tout cas, c'est cool.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=http%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F78106313"></iframe>
-
-(via
-[IGIF](http://www.iguessimfloating.net/2013/02/listen-field-mouse-tomorrow-is-yesterday.html))
+(via feu iguessimfloating.net)

--- a/2013/2013-03-01-young-man-in-a-sense.md
+++ b/2013/2013-03-01-young-man-in-a-sense.md
@@ -10,9 +10,8 @@ date: "2013-03-01 10:41:49 +0100"
 Le 3ème LP de Young Man, _Beyond Was All Around Me_, sort le 9 avril chez
 [French Kiss](http://www.frenchkissrecords.com/).
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=http%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F76892371"></iframe>
+{% spotify_track 0JaKU3pTJgACwYK5v0HED1 %}
 
 Vous pouvez aussi réécouter _Fate_ [ici](700).
 
-(via
-[IGIF](http://www.iguessimfloating.net/2013/02/listen-young-man-in-a-sense.html))
+(via feu iguessimfloating.net)

--- a/2013/2013-03-13-sister-crystals-for-so-long.md
+++ b/2013/2013-03-13-sister-crystals-for-so-long.md
@@ -9,7 +9,6 @@ date: "2013-03-13 10:00:00 +0100"
 
 Le groupe sort son 1er LP éponyme en mai.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=http%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F81707814"></iframe>
+{% soundtrack 81707814 %}
 
-(via
-[IGIF](http://www.iguessimfloating.net/2013/03/listen-sister-crystals-for-so-long.html))
+(via feu iguessimfloating.net)

--- a/2013/2013-04-09-shy-boys-julia.md
+++ b/2013/2013-04-09-shy-boys-julia.md
@@ -11,7 +11,6 @@ Jolie découverte de la semaine : Shy Boys. Trois titres sont en écoute sur
 [leur page Soundcloud](https://soundcloud.com/shhyboys). Ils sont tous bons mais
 il a bien fallu en choisir un :
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=http%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F85627874"></iframe>
+{% soundcloud 85627874 %}
 
-(via
-[IGIF](http://www.iguessimfloating.net/2013/04/listen-shy-boys-ride-julia.html))
+(via feu iguessimfloating.net)

--- a/2013/2013-04-12-tropical-popsicle-ghost-beacons.md
+++ b/2013/2013-04-12-tropical-popsicle-ghost-beacons.md
@@ -7,11 +7,10 @@ wordpress_id: 1217
 date: "2013-04-12 10:00:00 +0200"
 ---
 
-{The Dawn Of Delight}, le 1er LP de Tropical Popsicle arrive. Ce groupe de San
+_The Dawn Of Delight_, le 1er LP de Tropical Popsicle arrive. Ce groupe de San
 Diego semble être l'oeuvre d'un dénommé Tim Hines, qui fait tout tout seul, de
 la musique à la pochette, à l'exception de ce titre, fait à plusieurs mains.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=http%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F53075947"></iframe>
+{% soundcloud 53075947 %}
 
-via
-[IGIF](http://www.iguessimfloating.net/2013/03/listen-topical-popsicle-the-dawn-of-delight-lp.html)
+(via feu iguessimfloating.net)

--- a/2013/2013-05-24-tv-girl-she-smokes-in-bed.md
+++ b/2013/2013-05-24-tv-girl-she-smokes-in-bed.md
@@ -7,9 +7,8 @@ wordpress_id: 1236
 date: "2013-05-24 12:18:35 +0200"
 ---
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=http%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F93436394"></iframe>
+{% soundcloud 93436394 %}
 
 Fumer au lit c'est mal. À ne pas reproduire chez vous !
 
-(via
-[IGIF](http://www.iguessimfloating.net/2013/05/mp3-tv-girl-she-smokes-in-bed.html))
+(via feu iguessimfloating.net)


### PR DESCRIPTION
The legitimate and greatly appreciated iguessimfloating.net is now linking to some Japanese (?) weird ads.

This PR removes all the links towards it.