### PR TITLE
Fix leftover markdown linting issues

### DIFF
--- a/.mdlrc
+++ b/.mdlrc
@@ -1,1 +1,0 @@
-style "#{File.dirname(__FILE__)}/markdownlint_style.rb"

--- a/2011/2011-09-16-fun-friday-11.md
+++ b/2011/2011-09-16-fun-friday-11.md
@@ -39,7 +39,7 @@ de manière fun.
 
 {% youtube L7estuFU6VU %}
 
-## C'est qui ça Arcade Fire ?!
+## C'est qui ça Arcade Fire ?
 
 On a beau vivre dans le même monde, des murs d'incompréhension se dressent
 parfois entre nous de temps en temps. Ainsi, lors de la victoire d'Arcade Fire
@@ -47,11 +47,10 @@ pour le Grammy Award du meilleur disque 2010, Twitter a été envahi de messages
 du type : "Arcade Fire ?! Mais c'est qui ça ?!"
 
 Vous en trouverez une belle brochette
-[ici](http://www.brooklynvegan.com/archives/2011/02/who_is_this_arc.html). 
-Voilà même de quoi inspirer des gens pour construire un site relayant les
-messages des gens diffusant publiquement leur méconnaissance d'Arcade Fire sur
-le Tumblr [Who Is Arcade Fire??!!?](http://whoisarcadefire.tumblr.com/). C'est
-assez fun.
+[ici](http://www.brooklynvegan.com/archives/2011/02/who_is_this_arc.html). Voilà
+même de quoi inspirer des gens pour construire un site relayant les messages des
+gens diffusant publiquement leur méconnaissance d'Arcade Fire sur le Tumblr
+[Who Is Arcade Fire??!!?](http://whoisarcadefire.tumblr.com/). C'est assez fun.
 
 ## Citations de Rockers
 

--- a/2011/2011-12-09-guitar-army-john-sinclair.md
+++ b/2011/2011-12-09-guitar-army-john-sinclair.md
@@ -91,7 +91,7 @@ communautaire hippie :
   amis car elle était hippie et vivait en communauté - l'homme en question fut
   condamné mais reçut des centaines de lettres de soutien)
 
-## L'herbe et le LSD, oui ! L'alcool et l'héroïne, non !
+## L'herbe et le LSD : oui, l'alcool et l'héroïne : non
 
 Pour Sinclair, la jeunesse américaine doit prendre le pouvoir. Il prône un
 message pacifiste, dénigre

--- a/2017/2017-01-17-compile-automne-2016-face-B.md
+++ b/2017/2017-01-17-compile-automne-2016-face-B.md
@@ -11,7 +11,7 @@ description: >
   la face B.
 ---
 
-## Soyons précis !
+## Soyons précis
 
 Voyez, moi, j'ai toujours été très compile. Les compiles et moi, c'est une
 vieille histoire, commencée tout gosse. Alors quand on parle de compile, faut

--- a/2017/2017-04-03-compile-hiver-2017.md
+++ b/2017/2017-04-03-compile-hiver-2017.md
@@ -19,7 +19,7 @@ famille et plus globalement pour accompagner tous les moments sweet de votre
 vie. N'hésitez pas à vous en servir dès que possible, dans les jours, les mois,
 les années à venir !
 
-## Réveillonnons !
+## Réveillonnons
 
 La soirée commence avec un beau bouquet, estampillé “joie d'offrir une droite,
 plaisir de recevoir une mandale”. Tout le petit monde calmé, l'esprit de noël
@@ -36,7 +36,7 @@ apparaître un beau dessin : serait-ce un **appuie-tête** ?!?
 Puis vient la messe de minuit. On fête la famille, _l'amour_ et la joie. Et on
 se met tous autour du piano pour quelques chants de noël.
 
-## Réveillons-nous !
+## Réveillons-nous
 
 Le temps file, déjà la fin de soirée ou le début de la journée suivante. On
 jette ses dernières forces dans un dernier chant trop trop mignon. Ah non,

--- a/2018/2018-02-27-water-music.md
+++ b/2018/2018-02-27-water-music.md
@@ -15,7 +15,7 @@ Faut-il parler compile quand on fait un article sur une compile ? Ne se
 suffit-elle pas à elle-même ? En l'occurrence, pour la face A de l’Automne 2017
 selon Dead Rooster, j’avais le choix.
 
-## Ciao les artistes !
+## Ciao les artistes
 
 J'aurais d'abord pu évoquer les quelques disparus mis à l'honneur ici. Pas mal
 de matière s'offrait à moi. Et déjà, le débat : "pour ou contre Johnny ?". Trop
@@ -37,7 +37,7 @@ d'auto-congratulation !
 
 {% asset simpsons-rock.png %}
 
-## Paf le chien !
+## Paf le chien
 
 Sinon, j'aurais pu faire un article désopilant, évoquant les morceaux funs de la
 compile. Mener une enquête de fond sur Marie Möör : qui est-elle ? Quelle est la
@@ -74,7 +74,7 @@ two, excusez du peu.
 
 {% youtube JxCg_ROKfcU %}
 
-## Le bouquin ?
+## Le bouquin ?
 
 Non, c'est décidé, je ne parlerai pas de musique, mais plutôt d'un excellent
 roman : _Water Music_, de T.C. Boyle. Alors, bien sûr, je vous vois venir, tous

--- a/markdownlint_style.rb
+++ b/markdownlint_style.rb
@@ -1,3 +1,0 @@
-all
-
-rule 'MD026', punctuation: '.,;:'


### PR DESCRIPTION
It turns out the markdown lint instance used by Github is not the Ruby one. 🤦‍♂️
After rethinking it, their default rules are very reasonable, so let's stick with them. 