### PR TITLE
Fix broken markup and forgotten unbreakable spaces

### DIFF
--- a/2006/2006-09-28-vincent-delerm-les-piqures-d-araignee.md
+++ b/2006/2006-09-28-vincent-delerm-les-piqures-d-araignee.md
@@ -58,10 +58,10 @@ de ses années lycée/fac.
 Mais encore une fois, il transcende ses histoires individuelles, et parvient à
 les rendre évocatrices pour tous : qui n'a jamais fantasmer sur *Les jambes de
 Steffi Graf* ? ("Anna Kournikova", c'était trop long…) Qui n'a jamais décortiqué
-en quête de sens le livret de son disque préféré quand passe sa chanson favorite
-? C'est ici le thème de _Favorite song_, ma chanson préférée de l'album (ça
-tombe bien !) où le duo Delerm/Hannon est parfait, l'un qui dit avoir été fan et
-l'être encore de la Comédie Divine, chanter sa chanson préférée sans en
+en quête de sens le livret de son disque préféré quand passe sa chanson
+favorite ? C'est ici le thème de _Favorite song_, ma chanson préférée de l'album
+(ça tombe bien !) où le duo Delerm/Hannon est parfait, l'un qui dit avoir été
+fan et l'être encore de la Comédie Divine, chanter sa chanson préférée sans en
 comprendre un mot; l'autre se questionnant sur la signification de "javanaise",
 "poinçonneur des lilas", "poupée de cire"…
 

--- a/2007/2007-02-09-pamphlet-anti-chanson-cachee.md
+++ b/2007/2007-02-09-pamphlet-anti-chanson-cachee.md
@@ -25,9 +25,9 @@ l'auditeur ? Lui asséner le coup de grâce avec la chanson qui tue et à laque
 il ne s'attend pas ? Remplir le disque (le fameux syndrôme du pourquoi
 j'achèterai du 43 si c'est le même prix que le 45, déjà dénoncé par Coluche en
 son temps) ? Emmerder le iPoder, contraint de patienter un quart d'heure à la
-fin du disque pour entendre 2 minutes de bruits tordus parfaitement anecdotiques
-? Non, non, non, je ne cromprends pas. Aucune chanson cachée n'a révolutionné la
-musique que je sache.
+fin du disque pour entendre 2 minutes de bruits tordus parfaitement
+anecdotiques ? Non, non, non, je ne cromprends pas. Aucune chanson cachée n'a
+révolutionné la musique que je sache.
 
 Pire encore, quelques petits malins (Liars, The Polyphonic Spree, Camille, je
 parle de vous, entre autres) ont aussi mis en œuvre la boucle sonore jusqu'à la

--- a/2007/2007-04-11-man-u-as-roma-7-1.md
+++ b/2007/2007-04-11-man-u-as-roma-7-1.md
@@ -34,11 +34,11 @@ Mais John "unlucky" Smith avait mal choisi son jour !!!!
 
 Et c'est Alex Johnson, 71 ans, qui a empoché hier la somme rondelette de 2 132
 233 £. Le septuagénaire, à l'annonce de ce gain, décéda d'une crise cardiaque.
-Quant à Suzanne, veuve Smith, elle fait preuve du légendaire flegme britannique
-: "en hommage à mon défunt mari, je suivrai désormais sa ligne de conduite, et
-pronostiquerait jusqu'à la fin de mes jours la victoire de Liverpool, ma ville
-de naissance, sur le score de 10-4, en souvenir de la date funeste… Et qui sait
-? Peut-être serai-je millionaire dès demain !"
+Quant à Suzanne, veuve Smith, elle fait preuve du légendaire flegme
+britannique : "en hommage à mon défunt mari, je suivrai désormais sa ligne de
+conduite, et pronostiquerait jusqu'à la fin de mes jours la victoire de
+Liverpool, ma ville de naissance, sur le score de 10-4, en souvenir de la date
+funeste… Et qui sait ? Peut-être serai-je millionaire dès demain !"
 
 C'est tout le bien qu'on lui souhaite !
 

--- a/2007/2007-05-19-back-to-the-future.md
+++ b/2007/2007-05-19-back-to-the-future.md
@@ -8,8 +8,8 @@ date: "2007-05-19 06:40:00 +0200"
 cover: smashing-pumpkins-zeitgeist.jpg
 ---
 
-Nom de Zeus ! Une nouvelle brèche dans le continuum spatio-temporel est ouverte
-:
+Nom de Zeus ! Une nouvelle brèche dans le continuum spatio-temporel est
+ouverte :
 [http://www.spinner.com/2007/05/18/new-music-tarantula-by-smashing-pumpkins/](http://www.spinner.com/2007/05/18/new-music-tarantula-by-smashing-pumpkins/)
 
 Faut pas trop réfléchir Mc Fly !!! Allez, vite, dans la DeLorean ! Filons à

--- a/2007/2007-07-13-grande-saga-quot-un-mois-de-juin-2007-rock-n-roll-quot-episode-1-sur-5-the-who-a-bercy.md
+++ b/2007/2007-07-13-grande-saga-quot-un-mois-de-juin-2007-rock-n-roll-quot-episode-1-sur-5-the-who-a-bercy.md
@@ -15,9 +15,9 @@ tags:
 cover: the-who-pete-townshend.jpg
 ---
 
-Cette année, boycott du concert des Rolling Stones au Stade de France ! Pourquoi
-? Parce que j'ai déjà pris ma place pour les Who et que je m'impose la règle
-"pas plus d'un concert à 50 balles par mois" !
+Cette année, boycott du concert des Rolling Stones au Stade de France !
+Pourquoi ? Parce que j'ai déjà pris ma place pour les Who et que je m'impose la
+règle "pas plus d'un concert à 50 balles par mois" !
 
 Bref, au mois de juin, direction Bercy (quelle horreur cette salle) pour aller
 voir **The Who** !

--- a/2007/2007-10-08-le-patinage-artistique-meprise.md
+++ b/2007/2007-10-08-le-patinage-artistique-meprise.md
@@ -8,5 +8,5 @@ date: "2007-10-08 17:16:00 +0200"
 cover: blades-of-glory.jpg
 ---
 
-Seules 7 salles en France daignent diffuser _Les rois du patin_. Le monde va mal
-!
+Seules 7 salles en France daignent diffuser _Les rois du patin_. Le monde va
+mal !

--- a/2007/2007-11-13-des-idoles-ne-connaissent-pas-l-idole.md
+++ b/2007/2007-11-13-des-idoles-ne-connaissent-pas-l-idole.md
@@ -10,5 +10,5 @@ cover: johnny-hallyday.png
 
 Hier, pendant le Grand Journal, on a pu entendre Angelina Jolie dire dans la
 langue de Shakespeare : "Je ne connais pas Johnny Hallyday". Comment peut-on
-laisser des hommes et des femmes vivre sans connaître l'idole ? Le monde va mal
-!
+laisser des hommes et des femmes vivre sans connaître l'idole ? Le monde va
+mal !

--- a/2008/2008-06-19-y-a-un-feminin-a-regis.md
+++ b/2008/2008-06-19-y-a-un-feminin-a-regis.md
@@ -17,6 +17,6 @@ comments:
 cover: with-stupid.jpg
 ---
 
-Aujourd'hui, j'ai encore entendu une conne s'égosiller d'un lamentablement plat
-: "de toute façon le foot, c'est juste regarder des gugusses qui courent après
-un ballon". Le monde va mal !
+Aujourd'hui, j'ai encore entendu une conne s'égosiller d'un lamentablement
+plat : "de toute façon le foot, c'est juste regarder des gugusses qui courent
+après un ballon". Le monde va mal !

--- a/2008/2008-11-25-gallagher-comme-a-la-guerre.md
+++ b/2008/2008-11-25-gallagher-comme-a-la-guerre.md
@@ -17,9 +17,9 @@ cover: oasis.jpg
 ---
 
 Combien de jeux de mots pourris (Noel en Novembre, **Oasis** : la traversée du
-désert, Du vague à Liam) ? Combien de critiques narquoises ? Combien de : "Oasis
-? Ouais, on les entend plus depuis _Wonderwall_ tes potes !" ? Combien de :
-"Oasis est de retour !" ? Alors qu'ils ne sont jamais partis les frangins.
+désert, Du vague à Liam) ? Combien de critiques narquoises ? Combien de :
+"Oasis ? Ouais, on les entend plus depuis _Wonderwall_ tes potes !" ? Combien
+de : "Oasis est de retour !" ? Alors qu'ils ne sont jamais partis les frangins.
 
 Alors certes, les médias ne leur accordent plus la place qu'ils s'étaient
 octroyés à la sueur de leurs gros sourcils au milieu des années 90. Mais tout de
@@ -120,8 +120,8 @@ que d'assister au concert du Bataclan, complet en moins de temps qu'il n'en faut
 pour dire un million de fois "We're fookin' good !" ? Cependant, des peurs
 peuvent être alimentées : et si Noel jouait sur une chaise, rapport à ses côtes
 fracturées lors d'un duel perdu contre un forcené canadien ? (en même temps, il
-avait les mains prises par sa guitare, c'était pas très équilibré comme combat
-!). Et si Zak Starkey, démissionnaire pour cause officielle de "problèmes
+avait les mains prises par sa guitare, c'était pas très équilibré comme
+combat !). Et si Zak Starkey, démissionnaire pour cause officielle de "problèmes
 familiaux", nous laisser avec un batteur à deux balles ?
 
 Pour parler franc, une partie de nos doutes ont été confirmés. En effet, à la

--- a/2009/2009-02-10-bertrand-burgalat-april-march.md
+++ b/2009/2009-02-10-bertrand-burgalat-april-march.md
@@ -27,16 +27,16 @@ Gainsbourg : _Laisse tomber les filles_ (donc), _Caribou_, _La Chanson de
 Prévert_, _Cet air-là_, etc…
 
 Rien d'anormal donc à ce qu'elle finisse par rencontrer **Bertrand Burgalat**,
-chef de tribu, via son label Tricatel ([nom inspiré de _l'Aile ou la Cuisse_
-?][2]), de ce qui se fait de mieux en matière de revival de pop/yéyé élégante
-d'ascendance gainsbourienne. Il produit en effet Katerine, A.S Dragon, Héléna
-Noguerra ou Valérie Lemercier mais aussi d'autres opus ovnis, à la croisée des
-chemins du rock et de la littérature, comme ces disques de Michel Houellebecq ou
-de Jonathan Coe. Lui-même est d'ailleurs musicien et propose ces semaines-ci une
-tournée d'adieu (à prendre au sérieux ?) en compagnie de sa muse April March
-pour lequel il a écrit deux disques de très haut niveau (quoiqu'assez
-radicalement différent de son _Chick Habit_ ou de ses fulgurances garage
-fabriquées avec The Makers) : _Chrominance Decoder_ et _Triggers_.
+chef de tribu, via son label Tricatel ([nom inspiré de *l'Aile ou la
+Cuisse* ?][2]), de ce qui se fait de mieux en matière de revival de pop/yéyé
+élégante d'ascendance gainsbourienne. Il produit en effet Katerine, A.S Dragon,
+Héléna Noguerra ou Valérie Lemercier mais aussi d'autres opus ovnis, à la
+croisée des chemins du rock et de la littérature, comme ces disques de Michel
+Houellebecq ou de Jonathan Coe. Lui-même est d'ailleurs musicien et propose ces
+semaines-ci une tournée d'adieu (à prendre au sérieux ?) en compagnie de sa muse
+April March pour lequel il a écrit deux disques de très haut niveau
+(quoiqu'assez radicalement différent de son _Chick Habit_ ou de ses fulgurances
+garage fabriquées avec The Makers) : _Chrominance Decoder_ et _Triggers_.
 
 Pas de première partie ce mercredi 28 janvier, à l'Elysée Montmartre. Quelques
 figures notables ont pris place autour de la scène (Michka Assayas et Héléna

--- a/2009/2009-03-10-l-homme-gris-est-de-retour.md
+++ b/2009/2009-03-10-l-homme-gris-est-de-retour.md
@@ -8,5 +8,5 @@ date: "2009-03-10 14:15:00 +0100"
 cover: bambi.jpg
 ---
 
-Michael Jackson est de retour, il donnera des concerts cet été. Le monde va mal
-!
+Michael Jackson est de retour, il donnera des concerts cet été. Le monde va
+mal !

--- a/2009/2009-09-03-rien-n-a-change-ben-la-ca-a-change-non.md
+++ b/2009/2009-09-03-rien-n-a-change-ben-la-ca-a-change-non.md
@@ -9,5 +9,5 @@ cover: les-poppys.jpg
 ---
 
 Jean Amoureux, le créateur des petits chanteurs d'Asnières et des
-[Poppys](http://www.youtube.com/watch?v=V9Po8lSIKww), est mort. Le monde va mal
-!
+[Poppys](http://www.youtube.com/watch?v=V9Po8lSIKww), est mort. Le monde va
+mal !

--- a/2009/2009-10-06-cine-club-moi-j-vous-dis-01.md
+++ b/2009/2009-10-06-cine-club-moi-j-vous-dis-01.md
@@ -12,10 +12,10 @@ tags:
   - Cinéma
 ---
 
-_Casablanca_, œuvre magistrale ! _Le Cuirassé Potemkine_, n'en parlons même pas
-! Quant à _Citizen Kane_, le meilleur de tous ! Ok, mais comment faire pour voir
-ces films anciens, boudés par la télé et trop peu repris par les cinémas ? Pour
-ma part, la solution a été un abonnement à un service de location de DVD en
+_Casablanca_, œuvre magistrale ! _Le Cuirassé Potemkine_, n'en parlons même
+pas ! Quant à _Citizen Kane_, le meilleur de tous ! Ok, mais comment faire pour
+voir ces films anciens, boudés par la télé et trop peu repris par les cinémas ?
+Pour ma part, la solution a été un abonnement à un service de location de DVD en
 ligne : Glowria. Trois DVD par mois dont voici détaillée la livrée de septembre…
 
 ## _Pauline à la plage_ - Eric Rohmer (1983)
@@ -83,8 +83,7 @@ jalouser…
 
 Film fantastique et d'angoisse assez court (1h10), l'oeuvre de Tourneur n'en est
 pas moins efficace. On flippe un peu, et encore une fois, c'est sur
-[les recommandations de Serge Kaganski](http://blogs.lesinrocks.com/s-kaganski/?p=206)
-!
+[les recommandations de Serge Kaganski](http://blogs.lesinrocks.com/s-kaganski/?p=206) !
 
 **La chanson qui va avec** : fastoche, la chanson éponyme (et pas la meileure)
 de David Bowie !

--- a/2009/2009-10-18-500-nicolas-et-max.md
+++ b/2009/2009-10-18-500-nicolas-et-max.md
@@ -133,11 +133,11 @@ d'Agnan, qui arrivent à faire lever une paupière de temps en temps…
 Tout cela est terriblement décevant de la part d'un bonhomme qui avait du crédit
 depuis _Mensonges et trahisons et plus si affinités…_ et qui le consomme bien
 rapidement. Dans ce film avec Edouard Baer et Clovis Cornillac, il avait réussi
-à imprimer sur pellicule l'une des plus grandes légendes urbaines contemporaines
-: le sanglier accidenté qu'on met dans le coffre alors qu'il n'est pas encore
-vraiment mort. Big up également à Rémi Bezançon, qui s'était occupé de la
-légende du permis raté à cause du chien qui traverse la route dans _Le Premier
-jour du reste de ta vie_.
+à imprimer sur pellicule l'une des plus grandes légendes urbaines
+contemporaines : le sanglier accidenté qu'on met dans le coffre alors qu'il
+n'est pas encore vraiment mort. Big up également à Rémi Bezançon, qui s'était
+occupé de la légende du permis raté à cause du chien qui traverse la route dans
+_Le Premier jour du reste de ta vie_.
 
 {% youtube oJ77y9xGgRU %}
 

--- a/2009/2009-10-25-noah-et-la-baleine.md
+++ b/2009/2009-10-25-noah-et-la-baleine.md
@@ -56,8 +56,8 @@ ukulélés entrent en sus, on dit "love" à chaque fin de phrase et on ajoute un
 son très rigolo qui rappelle les moments où Yoshi se fait dégommer sur Super
 Mario World (à 3:13). Et moi, excusez-moi mais merde, j'adore ça ! Pour le reste
 quelques chansons honorables et plusieurs titres anecdotiques mais jamais
-repoussants. Mais que cachent ces titres "anecdotiques mais jamais repoussants"
-?
+repoussants. Mais que cachent ces titres "anecdotiques mais jamais
+repoussants" ?
 
 (entracte, profitons-en pour regarder les très marrants clips d'inspiration
 wesandersonienne très marquée des deux joyaux mentionnés en cliquant

--- a/2010/2010-02-10-l-idole-degueule.md
+++ b/2010/2010-02-10-l-idole-degueule.md
@@ -9,5 +9,5 @@ cover: toilettes-cassees.jpg
 ---
 
 Alors comme ça,
-[Johnny ne boirait pas que du "Legal-le goût"](http://www.youtube.com/v/evhcj2IjlO0)
-? Le monde va mal !
+[Johnny ne boirait pas que du "Legal-le goût"](http://www.youtube.com/v/evhcj2IjlO0) ?
+Le monde va mal !

--- a/2010/2010-04-03-les-dents-en-caoutchouc-de-la-mer.md
+++ b/2010/2010-04-03-les-dents-en-caoutchouc-de-la-mer.md
@@ -19,11 +19,11 @@ cover: faux-raccord.png
 Depuis une dizaine de semaines, Allociné propose une émission bien marrante :
 [**Faux Raccord**](http://www.allocine.fr/video/faux-raccords/).
 
-Chaque samedi, cette émission met en lumière les faux raccords de films célèbres
-: _Gladiator_, la trilogie Jason Bourne, _Pirates des Caraïbes_, etc. Au menu
-cette semaine, [_Les Dents de la Mer_][2] qui, bizarrement, me fout nettement
-moins les jetons qu'il y a 20 ans… Par contre, malheur, l'émission devient
-bihebdomadaire.
+Chaque samedi, cette émission met en lumière les faux raccords de films
+célèbres : _Gladiator_, la trilogie Jason Bourne, _Pirates des Caraïbes_, etc.
+Au menu cette semaine, [_Les Dents de la Mer_][2] qui, bizarrement, me fout
+nettement moins les jetons qu'il y a 20 ans… Par contre, malheur, l'émission
+devient bihebdomadaire.
 
 [Jonathan Lambert avait bien essayé de dénoncer les faux raccords en son
 temps][1], mais, images à l'appui, c'est quand même bien plus efficace.

--- a/2010/2010-04-13-le-1er-titre-du-printemps.md
+++ b/2010/2010-04-13-le-1er-titre-du-printemps.md
@@ -22,9 +22,9 @@ free MP3 bla bla bla" dans la section "Similaire à"), dont on peut voir le clip
 plus bas.
 
 Y figurent les 5 membres du groupe, en poncho et masqués, qui viennent ligoter
-une fille avec des jacks dans la neige. Tordu. Heureusement il y a un happy-end
-: la fille se libère et reste pote avec eux : elle leur offre même des pommes
-dans un nid. Encore plus tordu.
+une fille avec des jacks dans la neige. Tordu. Heureusement il y a un
+happy-end : la fille se libère et reste pote avec eux : elle leur offre même des
+pommes dans un nid. Encore plus tordu.
 
 Mais même si ça va nous faire faire des cauchemars, ça va aussi nous faire
 acheter un banjo !

--- a/2010/2010-05-19-qui-c-est-celui-la.md
+++ b/2010/2010-05-19-qui-c-est-celui-la.md
@@ -23,8 +23,7 @@ L'originale est ici :
 {% dailymotion xdi2a %}
 
 Et s'il vous plaît, respect au grand Pierre :
-[c'est pas tout le monde qui ouvre pour les Beatles à l'Olympia](http://fr.wikipedia.org/wiki/Pierre_Vassiliu)
-!
+[c'est pas tout le monde qui ouvre pour les Beatles à l'Olympia](http://fr.wikipedia.org/wiki/Pierre_Vassiliu) !
 
 C'était le dernier titre pronostiqué par Hervé qu'il lui manquait. Il marque 4
 nouveaux points et fait le grand chelem. Félicitations à lui mais m'est avis,

--- a/2010/2010-05-21-transat-pitch-de-poutch.md
+++ b/2010/2010-05-21-transat-pitch-de-poutch.md
@@ -8,8 +8,8 @@ date: "2010-05-21 12:18:44 +0200"
 cover: trimaran-crepes-wahou.jpg
 ---
 
-La nouvelle édifiante est [lisible][1] dans les colonnes de _L'équipe_. Je cite
-: "_Crêpes Whaou_ s'échappe".
+La nouvelle édifiante est [lisible][1] dans les colonnes de _L'équipe_. Je
+cite : "_Crêpes Whaou_ s'échappe".
 
 Ce que ne précise pas le quotidien sportif, c'est qu'il paraît qu'il a doublé
 _Bâtonnets Coraya_, mais que _Pic-Nic Break_ remonte en trombe… Par contre, on

--- a/2010/2010-06-22-toi-mon-toit.md
+++ b/2010/2010-06-22-toi-mon-toit.md
@@ -30,8 +30,8 @@ Quant à l'originale d'Elli Medeiros, là voilà :
 
 {% youtube mKsEBJdVvgI %}
 
-Encore une fois, personne ne l'avait pronostiqué et le classement reste inchangé
-:
+Encore une fois, personne ne l'avait pronostiqué et le classement reste
+inchangé :
 
 - 1. Hervé, 15pts
 - 2. Rodrigue et Joe, 5pts

--- a/2010/2010-07-24-la-nba-envahit-les-bacs.md
+++ b/2010/2010-07-24-la-nba-envahit-les-bacs.md
@@ -9,6 +9,6 @@ date: 2010-07-24 15:24:16 +0200
 ---
 
 [Rony Seikaly](http://en.wikipedia.org/wiki/Rony_Seikaly) est
-[DJ](http://www.thetripwire.com/news/2010/07/23/rony-seikaly-will-now-be-making-some-music-news-thank-you)
-? Peut-être mais moi, j'attends toujours un concert de Šarūnas Marčiulionis ! Le
+[DJ](http://www.thetripwire.com/news/2010/07/23/rony-seikaly-will-now-be-making-some-music-news-thank-you) ?
+Peut-être mais moi, j'attends toujours un concert de Šarūnas Marčiulionis ! Le
 monde va mal !

--- a/2010/2010-07-30-histoire-du-cinema-en-2-minutes.md
+++ b/2010/2010-07-30-histoire-du-cinema-en-2-minutes.md
@@ -11,7 +11,7 @@ cover: salle-de-cinema-vide.jpg
 date: 2010-07-30 21:30:52 +0200
 ---
 
-Après [l'histoire de l'art en 3 minutes](br143), voilà l'histoire du cinéma en 2
-!
+Après [l'histoire de l'art en 3 minutes](br143), voilà l'histoire du cinéma en
+2 !
 
 {% vimeo 13334581 %}

--- a/2010/2010-09-09-parfois-on-s-demande.md
+++ b/2010/2010-09-09-parfois-on-s-demande.md
@@ -43,8 +43,8 @@ Mais c’est génial comme groupe !!!”
 {% youtube Y1mYCa5I8hA %}
 
 Connaissant les goûts musicaux plutôt solides de la jeune fille, j’étais bien
-dans l’embarras ! Comment un groupe peut être “génial” avec un nom aussi pourri
-? Voulant me renseigner un peu, je me rends fissa sur
+dans l’embarras ! Comment un groupe peut être “génial” avec un nom aussi
+pourri ? Voulant me renseigner un peu, je me rends fissa sur
 [allmusic](http://allmusic.com/cg/amg.dll?p=amg&sql=11:k9fpxq9jldke). Grand mal
 m’en a pris !!! Non, mais sérieusement, qu’est-ce que c’est que ces pochettes
 hideuses ? C’est des fans de la variétoche américaine des 70s post-margarine à

--- a/2010/2010-10-15-de-la-biere-et-du-foot-de-la-musique-et-un-chien.md
+++ b/2010/2010-10-15-de-la-biere-et-du-foot-de-la-musique-et-un-chien.md
@@ -49,8 +49,7 @@ Profitons-en pour nous souvenir de Freddie Mercure :
 Par ailleurs, en ce qui concerne le biopic de Phil Spector (producteur génial
 des 60s, ayant plutôt mal vieilli : perruques et meurtre), le rôle serait tenu
 par Al Pacino, que j'aurais plutôt vu dans le rôle de Leonard Cohen
-([comme bien d'autres](http://i2.pinger.pl/pgr390/ea0abce00029a3bd4a147b97/al-pacino-totally-looks-like-leonard-cohen.jpg))
-:
+([comme bien d'autres](http://i2.pinger.pl/pgr390/ea0abce00029a3bd4a147b97/al-pacino-totally-looks-like-leonard-cohen.jpg)) :
 
 {% asset phil-spector-al-pacino.png %}
 

--- a/2010/2010-10-22-fun-friday-06.md
+++ b/2010/2010-10-22-fun-friday-06.md
@@ -55,8 +55,7 @@ d'ores-et-déjà leur participation au concours.
 
 Retour Vers Le Futur est le meilleur film de l'histoire, nous sommes d'accord.
 Et ben ça a failli être une belle merde,
-[images à l'appui](http://artsbeat.blogs.nytimes.com/2010/10/12/the-back-to-the-future-that-might-have-been/)
-!
+[images à l'appui](http://artsbeat.blogs.nytimes.com/2010/10/12/the-back-to-the-future-that-might-have-been/) !
 
 C'était en effet Eric Stoltz qui jouait Marty McFly dans le casting initial.
 Mais après plusieurs semaines de tournage, Zemeckis a convaincu Spielberg de

--- a/2010/2010-12-28-s-t-p-a-travers-l-amerique-avec-les-rolling-stones.md
+++ b/2010/2010-12-28-s-t-p-a-travers-l-amerique-avec-les-rolling-stones.md
@@ -63,8 +63,8 @@ Les Stones et les managers de la tournée sont des professionnels du star-system
 Les tournées, ils connaissent et en verront d'autres. Mais dans l'équipe STP
 figurent aussi des novices dont la vie se transforme par la tournée et
 Greenfield les observe et leur prédit un retour de bâton lorsqu'une seule pensée
-les paralysera une fois leur job sur la tournée terminé : "et maintenant quoi
-?".
+les paralysera une fois leur job sur la tournée terminé : "et maintenant
+quoi ?".
 
 Sur la route, des péripéties savoureuses ont lieu. A Chicago, le groupe loge
 quelques jours dans la demeure décadente du fondateur et propriétaire de
@@ -72,19 +72,20 @@ Playboy, Hugh Hefner. Plus tard, Mick Jagger préside un procès interne suite a
 passage à tabac d'un pote de Keith par un garde du corps. La plus épique reste
 l'arrestation du groupe avant un concert à Boston.
 
-Les mauvaises conditions météo empêchent l'avion des Stones de se poser à Boston
-: ils vont devoir atterrir à une bonne heure de route de là. Un photographe fan
-des Stones est mis au courant, se pointe à l'aéroport mais agace un peu trop
-Keith qui lui envoie un coup de ceinturon en pleine tronche. Le sergent de
-police en poste finit par embarquer tout le groupe en cellule. Pendant ce
-temps-là, au Boston Garden, Chip Monck doit gérer une foule de _kids_ qui attend
-de pied ferme le concert des Stones. Le héros de l'histoire est Kevin White, le
-maire de Boston, qui appelle le gouverneur de Rhode Island pour faire libérer
-les Stones, monte lui-même sur scène pour annoncer au public la raison du retard
-des Stones ainsi que leur arrivée prochaine, et promet que les transports en
-commun attendront la fin du concert - ce sera à deux heures du matin - pour
-ramener les spectateurs chez eux. Il paraît que sa popularité soudaine parmi la
-jeunesse de Boston aidera à le faire réélire quelques temps plus tard.
+Les mauvaises conditions météo empêchent l'avion des Stones de se poser à
+Boston : ils vont devoir atterrir à une bonne heure de route de là. Un
+photographe fan des Stones est mis au courant, se pointe à l'aéroport mais agace
+un peu trop Keith qui lui envoie un coup de ceinturon en pleine tronche. Le
+sergent de police en poste finit par embarquer tout le groupe en cellule.
+Pendant ce temps-là, au Boston Garden, Chip Monck doit gérer une foule de _kids_
+qui attend de pied ferme le concert des Stones. Le héros de l'histoire est Kevin
+White, le maire de Boston, qui appelle le gouverneur de Rhode Island pour faire
+libérer les Stones, monte lui-même sur scène pour annoncer au public la raison
+du retard des Stones ainsi que leur arrivée prochaine, et promet que les
+transports en commun attendront la fin du concert - ce sera à deux heures du
+matin - pour ramener les spectateurs chez eux. Il paraît que sa popularité
+soudaine parmi la jeunesse de Boston aidera à le faire réélire quelques temps
+plus tard.
 
 {% youtube ushiwMacvQw %}
 
@@ -94,11 +95,11 @@ souhaite un chaos total sur scène mais toutes ses idées finissent par arriver
 aux oreilles des dirigeants du Madison Square Garden qui les interdisent
 aussitôt : il n'y aura donc pas d'éléphant sur scène, ni de lâcher de ballons,
 de farine ou de poulets (deux complices ont pourtant fait un test concluant en
-lâchant un poulet du haut d'un building en plein Manhattan : ils savent voler
-!). D'ailleurs après l'idée des poulets, la direction du Garden fait colmater
-tous les orifices du toit. Ce sera donc finalement une simple bataille de tartes
-à la crème que Monck aura caché sur scène après s'être fait confisqué plusieurs
-cartons/leurres qui en étaient remplis.
+lâchant un poulet du haut d'un building en plein Manhattan : ils savent
+voler !). D'ailleurs après l'idée des poulets, la direction du Garden fait
+colmater tous les orifices du toit. Ce sera donc finalement une simple bataille
+de tartes à la crème que Monck aura caché sur scène après s'être fait confisqué
+plusieurs cartons/leurres qui en étaient remplis.
 
 La dernière page refermée, c'est inévitable, une envie frénétique surgit :
 trouver coûte que coûte le moyen de voir les images tournées par Robert Franck

--- a/2011/2011-02-08-the-doors-c-est-trop-bien-si-si-allez.md
+++ b/2011/2011-02-08-the-doors-c-est-trop-bien-si-si-allez.md
@@ -52,7 +52,7 @@ comments:
     author_email: dirtyhenry@gmail.com
     date: 2012-01-30 14:22:41 +0100
     title: The Doors, c'est trop bien ? Si, si, allez !
-    content: :) c'est de bonne guerre.
+    content: 😀 c'est de bonne guerre.
   - author: un fan
     author_email: charly_gutierrez@ymail.com
     date: 2012-04-20 14:23:03 +0200

--- a/2011/2011-02-11-fun-friday-08.md
+++ b/2011/2011-02-11-fun-friday-08.md
@@ -22,8 +22,7 @@ Connaissez-vous M. Mangetout ? J'ai découvert M. Mangetout grâce au site
 "pour lequel les affaires marchent fort : ils ont une
 [application iPhone](http://itunes.apple.com/fr/app/learn-something-every-day/id403233770?mt=8)
 et
-[un livre en précommande](http://www.amazon.com/Learn-Something-Every-Day-Young/dp/0399536663")
-:
+[un livre en précommande](http://www.amazon.com/Learn-Something-Every-Day-Young/dp/0399536663") :
 
 {% asset monsieur-mangetout.png %}
 

--- a/2011/2011-02-19-elvis-presley.md
+++ b/2011/2011-02-19-elvis-presley.md
@@ -59,11 +59,11 @@ militaire de Johnny Hallyday en 1964.
 
 Après plusieurs tentatives infructueuses à Hollywood, il se tourne vers le
 stand-up. Dans un souci d'exhaustivité, citons ici sa blague favorite qui
-consistait à demander à une complice dissimulée dans le public : "Salut ma belle
-! Comment je m'appelle ?", la jeune fille de répondre : "Presley !", et lui de
-conclure d'un simple "Pouet ! Pouet !" accompagné d'un geste libidineux sur la
-poitrine de son assistante… … … Humoriste visionnaire, trop en avance sur son
-temps et sur les mœurs d'une société américaine ultra-conservatrice, sa
+consistait à demander à une complice dissimulée dans le public : "Salut ma
+belle ! Comment je m'appelle ?", la jeune fille de répondre : "Presley !", et
+lui de conclure d'un simple "Pouet ! Pouet !" accompagné d'un geste libidineux
+sur la poitrine de son assistante… … … Humoriste visionnaire, trop en avance sur
+son temps et sur les mœurs d'une société américaine ultra-conservatrice, sa
 reconversion comique est un échec !
 
 En désespoir de cause, il revient à la chanson, avec son fameux _Aloha From

--- a/2011/2011-03-12-the-pixies.md
+++ b/2011/2011-03-12-the-pixies.md
@@ -58,9 +58,9 @@ comments:
 
 Grâce à cet article, faisons en sorte de ne pas oublier que plus d'une décennie
 avant The Strokes, The White Stripes et ce qu'on a appelé les groupes en "The",
-dès les années 80, une première vague de ce type a déferlé sur le monde musical
-: The R.E.M., The U2 ou encore The Radiohead. Et donc, dans le cas qui nous
-intéresse aujourd'hui : **The Pixies**.
+dès les années 80, une première vague de ce type a déferlé sur le monde
+musical : The R.E.M., The U2 ou encore The Radiohead. Et donc, dans le cas qui
+nous intéresse aujourd'hui : **The Pixies**.
 
 The Pixies est un groupe de Boston surtout connu du grand public pour avoir
 composé la BO de Fight Club. Il est constitué de Frank White au chant/guitare,
@@ -70,10 +70,10 @@ le genre à la guitare lead, et d'un batteur.
 En plus d'assurer le chant et la guitare rythmique, Jack White est aussi le
 principal compositeur du groupe. Mais en dépit de ce quasi-monopole, le groupe
 fonctionne vraiment grâce à l'alchimie existante entre ses membres. D'ailleurs,
-une fois The Pixies dissous, chaque membre peinera à retrouver le succès d'antan
-: Jack Black et ses Catholics aligneront des albums au mieux "fades", Kim
-parviendra à placer une seule chanson, Champagne Supernova au refrain péchu et
-entêtant ("Slowly walking down the hall/Faster than a cannonball"), au sommet
+une fois The Pixies dissous, chaque membre peinera à retrouver le succès
+d'antan : Jack Black et ses Catholics aligneront des albums au mieux "fades",
+Kim parviendra à placer une seule chanson, Champagne Supernova au refrain péchu
+et entêtant ("Slowly walking down the hall/Faster than a cannonball"), au sommet
 des charts avec Breeders, le groupe formé avec sa sœur.
 
 Ayant acquis un statut de _groupe culte_, les quatre bougres se réunissent

--- a/2011/2011-03-15-cine-club-moi-j-vous-dis-04.md
+++ b/2011/2011-03-15-cine-club-moi-j-vous-dis-04.md
@@ -70,10 +70,10 @@ majeur de Ludwig Von a un riff du tonnerre !
 
 {% youtube Y7F4z8FV6ME %}
 
-Même sur le domaine de la B.O., _Black Swan_ ne se montre pas hyper intéressant
-: du classique connu de tous (le motif principal du lac des cygnes, tout le
-monde connaît quand même, faut pas déconner) et The Chemical Brothers. La
-prochaine fois, Aronofsky n'aura qu'à blinder sa B.O. de Massive Attack et on
+Même sur le domaine de la B.O., _Black Swan_ ne se montre pas hyper
+intéressant : du classique connu de tous (le motif principal du lac des cygnes,
+tout le monde connaît quand même, faut pas déconner) et The Chemical Brothers.
+La prochaine fois, Aronofsky n'aura qu'à blinder sa B.O. de Massive Attack et on
 sera fâchés pour la vie… Pour fêter ça, allez, un peu de ska !
 
 {% youtube -utkYnIV1_k %}

--- a/2011/2011-03-15-la-politique-sans-grand-homme.md
+++ b/2011/2011-03-15-la-politique-sans-grand-homme.md
@@ -11,5 +11,5 @@ date: 2011-03-15 18:49:14 +0100
 Alors que j'avais mis le champagne au frais pour célébrer le premier
 anniversaire du D.A.R.D., le parti politique de Patrick Sébastien, voilà que
 j'apprends que
-[le parti n'existe plus et s'est auto-dissous en juin](http://www.slate.fr/story/23171/patrick-sebastien-dard-ferme)
-? Le monde va mal !
+[le parti n'existe plus et s'est auto-dissous en juin](http://www.slate.fr/story/23171/patrick-sebastien-dard-ferme) ?
+Le monde va mal !

--- a/2011/2011-03-26-neil-young.md
+++ b/2011/2011-03-26-neil-young.md
@@ -21,10 +21,10 @@ comments:
 Songwriter américain, Neil Young a toujours été inspiré par les atmosphères
 urbaines. Il déteste la forêt, la campagne et parler de "musique des grands
 espaces" pour qualifier ses premiers albums serait totalement erroné ; il n'y a
-qu'à écouter _Are you ready for the city_ sur _Hardest_ pour s'en rendre compte
-: "Are you ready for the city, because it's time to go ?" répète inlassablement
-Neil, qui apparemment, est pressé de revoir le bitume et l'acier des mégalopoles
-où il a grandi.
+qu'à écouter _Are you ready for the city_ sur _Hardest_ pour s'en rendre
+compte : "Are you ready for the city, because it's time to go?" répète
+inlassablement Neil, qui apparemment, est pressé de revoir le bitume et l'acier
+des mégalopoles où il a grandi.
 
 Auto-proclamé "The Loser", en _hommage_ à un début de carrière difficile, passé
 dans l'ombre de ses compères Bill Cosby, Stephen Stills et Steve Nash au sein

--- a/2011/2011-04-02-oasis.md
+++ b/2011/2011-04-02-oasis.md
@@ -27,17 +27,17 @@ montée par les tabloïds qui espéraient retrouver le même climat tendu que ce
 des 60s avec le classique duel **The Who**/**The Kinks**, le leader d'Oasis,
 Noel Carragher, n'en reste pas moins un humaniste éclairé, espérant que bientôt,
 "tout le monde puisse guérir du sida". Avant de se raviser en rectifiant ses
-propos trop utopistes (et sans doute alcoolisés) et de déclarer, non sans humour
-: "Ou du moins, que plus personne n'ait la grippe en hiver !".
+propos trop utopistes (et sans doute alcoolisés) et de déclarer, non sans
+humour : "Ou du moins, que plus personne n'ait la grippe en hiver !".
 
 Liam Carragher, le frère de Noel, fait des merveilles au chant, tout en
 arrogance et en nonchalance. Sur le premier album _Supermario_, _Live Together_
 ou encore _R'n'B Star_ prouvent que le groupe a su digérer toutes ses influences
 pour en extraire la substantifique moelle et aboutir à l'album rock 90s parfait.
 
-Dans la foulée, le groupe enchaîne avec l'album _What's The Story (Morning Glory
-?)_, à la pochette mémorable (Noel qui traverse une rue de Liverpool au petit
-matin), et aux chansons si marquantes qu'elles deviendront des hymnes
+Dans la foulée, le groupe enchaîne avec l'album _What's The Story (Morning
+Glory?)_, à la pochette mémorable (Noel qui traverse une rue de Liverpool au
+petit matin), et aux chansons si marquantes qu'elles deviendront des hymnes
 générationnels : _Rock With It_, _Clairette Supernova_ et bien sûr _Wonderworld_
 et _Don't Look Back In Angle_.
 

--- a/2011/2011-04-05-keren-ann-101.md
+++ b/2011/2011-04-05-keren-ann-101.md
@@ -77,9 +77,9 @@ Nothing_, ou <strike>le _Blowin' in the wind_ de</strike> **reprenant** Dylan
 sur _Daddy, You Been On My Mind_.
 
 Mais Keren Ann n'est jamais aussi forte que lorsqu'elle touche la corde sensible
-et c'est finalement _Strange Weather_ qui me semble le meilleur titre de l'album
-: une belle mélodie, un chant intense, une production certes familière mais
-ambitieuse. Voilà la Keren Ann que l'on aime.
+et c'est finalement _Strange Weather_ qui me semble le meilleur titre de
+l'album : une belle mélodie, un chant intense, une production certes familière
+mais ambitieuse. Voilà la Keren Ann que l'on aime.
 
 J'avais bien aimé l'exercice de la [compile pour les nuls d'Interpol][i802],
 alors rebelote, outre le conseil d'écouter _La Disparition_, le meilleur album

--- a/2011/2011-04-12-cine-club-moi-j-vous-dis-05.md
+++ b/2011/2011-04-12-cine-club-moi-j-vous-dis-05.md
@@ -88,9 +88,9 @@ le précédent film de Benchetrit, lui aussi très bon. C'est une sorte de
 refaisant
 [_Le Parrain_](http://www.allocine.fr/film/fichefilm_gen_cfilm=1628.html) à la
 sauce
-[_C'est arrivé près de chez vous_](http://www.allocine.fr/film/fichefilm_gen_cfilm=7383.html)
-: le cadre et l'ambiance lose font très "cinéma belge" et rappellent également
-les passages plus potaches que glauques des films de
+[_C'est arrivé près de chez vous_](http://www.allocine.fr/film/fichefilm_gen_cfilm=7383.html) :
+le cadre et l'ambiance lose font très "cinéma belge" et rappellent également les
+passages plus potaches que glauques des films de
 [Delépine](http://www.allocine.fr/personne/fichepersonne_gen_cpersonne=2389.html)
 et
 [Kervern](http://www.allocine.fr/personne/fichepersonne_gen_cpersonne=97326.html).
@@ -146,8 +146,8 @@ depuis l'Oncle Boonme de l'année dernière. Bon sang, je suis peut-être con,
 peut-être pas assez touché par ce que parviennent à faire les vieillards,
 peut-être pas assez contemplatif (même si pour le coup, j'aime beaucoup
 _Somewhere_ par exemple), mais merde, comment est-il possible que
-[les critiques puissent être aussi unanimement positives sur ce film](http://www.allocine.fr/film/revuedepresse_gen_cfilm=180401.html)
-? On ne m'y prendra plus.
+[les critiques puissent être aussi unanimement positives sur ce film](http://www.allocine.fr/film/revuedepresse_gen_cfilm=180401.html) ?
+On ne m'y prendra plus.
 
 La musique qui va avec
 

--- a/2011/2011-04-26-eteignez-les-radiateurs.md
+++ b/2011/2011-04-26-eteignez-les-radiateurs.md
@@ -10,5 +10,5 @@ date: 2011-04-26 22:47:03 +0200
 
 J'apprends ce soir l'existence et, malheureusement, la mort d'une chanteuse punk
 nommée Poly Styrene. Là où c'est moche, c'est que ça fait longtemps que je n'ai
-pas de nouvelles de Plastic Bertrand. Je commence à avoir peur ! Le monde va mal
-!
+pas de nouvelles de Plastic Bertrand. Je commence à avoir peur ! Le monde va
+mal !

--- a/2011/2011-05-21-the-ramones.md
+++ b/2011/2011-05-21-the-ramones.md
@@ -30,5 +30,5 @@ elle, a toujours été le théâtre d'une bataille d'égos, d'où des changement
 d'effectif incessants : Dee Dee puis C.J. à la basse, mais combien de batteurs ?
 Marky, Fatty, Tommy, Groovy et consorts… Et puis, le temps fit son affaire, et
 décima les troupes. Un à un, tous les membres originaux passèrent l'arme à
-gauche, qui à cause d'un cancer, qui à cause d'une overdose. Mais gardons espoir
-! _Aujourd'hui ton amour, demain le monde !_
+gauche, qui à cause d'un cancer, qui à cause d'une overdose. Mais gardons
+espoir ! _Aujourd'hui ton amour, demain le monde !_

--- a/2011/2011-06-15-pulp-different-class.md
+++ b/2011/2011-06-15-pulp-different-class.md
@@ -22,12 +22,12 @@ tags:
   - Pulp
 ---
 
-Comment adapter une chanson de Renaud pour en faire un hymne absolu du rock indé
-? Comment de grande tige malingre peut-on devenir songwriter adulé ? Comment
-cristalliser pour l'éternité les questions intimes de tous les adolescents ou
-anciens adolescents tout en leur donnant l'occasion d'agiter sans complexe leur
-corps maladroit ? Jarvis Cocker et son groupe Pulp ont donné la réponse à ces
-questions en octobre 1995 avec leur album _Different Class_.
+Comment adapter une chanson de Renaud pour en faire un hymne absolu du rock
+indé ? Comment de grande tige malingre peut-on devenir songwriter adulé ?
+Comment cristalliser pour l'éternité les questions intimes de tous les
+adolescents ou anciens adolescents tout en leur donnant l'occasion d'agiter sans
+complexe leur corps maladroit ? Jarvis Cocker et son groupe Pulp ont donné la
+réponse à ces questions en octobre 1995 avec leur album _Different Class_.
 
 La frustration, a priori, c'est franchement pas cool. Mais quoiqu'on en pense,
 c'est le moteur de la vie et, mieux encore, la frustration permet de pouvoir
@@ -65,10 +65,10 @@ riches, la condescendance qui en résulte à l'égard des pauvres,
 l'incompréhension éternelle qui existera entre les deux camps : constat
 fataliste ne blâmant jamais la bonne volonté des deux camps, mais qui clôt toute
 tentative de débat. Si le propos est plutôt déprimant, la musique qui
-l'accompagne nuance la chose, et les derniers mots changent subtilement la donne
-: on ne va pas faire semblant d'être quelqu'un d'autre mais on va quand même
-réussir à vivre ensemble. C'est beau. Ça donnerait presque envie de chialer dans
-sa bière.
+l'accompagne nuance la chose, et les derniers mots changent subtilement la
+donne : on ne va pas faire semblant d'être quelqu'un d'autre mais on va quand
+même réussir à vivre ensemble. C'est beau. Ça donnerait presque envie de chialer
+dans sa bière.
 
 Je pourrais m'enthousiasmer autant sur tous les titres de l'album.
 [_Disco 2000_](http://youtu.be/qJS3xnD7Mus) par exemple, où un gars, adulte,

--- a/2011/2011-08-15-submarine-richard-ayoade.md
+++ b/2011/2011-08-15-submarine-richard-ayoade.md
@@ -34,8 +34,8 @@ visiblement prometteur - et qui vient de publier un nouveau roman, _Wild
 Abandon_ - et c’est également le premier film réalisé par l’anglais Richard
 Ayoade, qui s’est fait connaître dans le petit monde de l’humour geek en
 interprétant le rôle de Maurice Moss dans la série anglaise _The IT Crowd_. Une
-doublette de débutants qui fait mouche puisque le film séduit sur tous les plans
-: scénario, style et musique.
+doublette de débutants qui fait mouche puisque le film séduit sur tous les
+plans : scénario, style et musique.
 
 Ayoade est visiblement quelqu’un à suivre de près. Outre _The IT Crowd_, son
 parcours est déjà très riche et intéressant puisque son CV inclut entre autres

--- a/2011/2011-08-20-yes.md
+++ b/2011/2011-08-20-yes.md
@@ -25,8 +25,8 @@ Non, là où le bât blesse, c'est visuellement et musicalement quoi. Déjà, on
 pas idée de jouer sur
 [cette guitare](http://images4.wikia.nocookie.net/__cb20091112203260/uncyclopedia/images/c/c0/Squire_Weapon.jpg)
 hein ! Et ce
-[logo](http://www.livemusicnewsandreview.com/Content/NetSite_1109/_groups/505/pages/YesLogoFullCircle1.jpg)
-? On dirait un mauvais logo de TF1 des eighties mélangé avec celui d'Antenne 2
+[logo](http://www.livemusicnewsandreview.com/Content/NetSite_1109/_groups/505/pages/YesLogoFullCircle1.jpg) ?
+On dirait un mauvais logo de TF1 des eighties mélangé avec celui d'Antenne 2
 d'avant celui avec la pomme…
 
 Et le plus triste, c'est que le seul numéro 1 du groupe au final, personne ne

--- a/2011/2011-09-01-the-la-s-a-rock-en-seine-que-penser.md
+++ b/2011/2011-09-01-the-la-s-a-rock-en-seine-que-penser.md
@@ -65,18 +65,18 @@ pelouse du parc de Saint-Cloud pour le concert annoncé sans fanfares ni
 trompettes de The La's. Avant de parler du concert, voici quelques extraits des
 reviews qui en ont été faites :
 
-[JD Beauvallet pour Les Inrocks](http://www.lesinrocks.com/musique/musique-article/t/69409/date/2011-08-28/article/on-y-est-rock-en-seine-jour-1/)
-: «[Mavers offre] de ses joyaux de chansons des versions d'ivrognes de pub des
-bas quartiers de Liverpool. (…) Mavers, barricadé derrière ses Ray-Bans (…)
-continue le massacre, avec une désinvolture et une approximation qui mériterait
-des seaux d'eau un soir de la fête de la musique. Il fait même tellement de mal
-à son intouchable _There She Goes_ qu'on songe à grimper sur scène pour
-l'empêcher, camisole de force en main, de nuire, de faire mal à ses propres
-enfants. Navrant spectacle, qui tourne au vaudeville quand il grimpe sur une
-batterie pour un solo ivre. On ne dit plus les La's, ont dit les Nazes.»
+[JD Beauvallet pour Les Inrocks](http://www.lesinrocks.com/musique/musique-article/t/69409/date/2011-08-28/article/on-y-est-rock-en-seine-jour-1/) :
+«[Mavers offre] de ses joyaux de chansons des versions d'ivrognes de pub des bas
+quartiers de Liverpool. (…) Mavers, barricadé derrière ses Ray-Bans (…) continue
+le massacre, avec une désinvolture et une approximation qui mériterait des seaux
+d'eau un soir de la fête de la musique. Il fait même tellement de mal à son
+intouchable _There She Goes_ qu'on songe à grimper sur scène pour l'empêcher,
+camisole de force en main, de nuire, de faire mal à ses propres enfants. Navrant
+spectacle, qui tourne au vaudeville quand il grimpe sur une batterie pour un
+solo ivre. On ne dit plus les La's, ont dit les Nazes.»
 
-[Philippe Brochen pour Libération](http://next.liberation.fr/musique/01012356529-rock-en-seine-ne-prend-pas-l-eau)
-: «vautrage historique du prétentieux Lee Mavers à Rock en Seine. (…) on aurait
+[Philippe Brochen pour Libération](http://next.liberation.fr/musique/01012356529-rock-en-seine-ne-prend-pas-l-eau) :
+«vautrage historique du prétentieux Lee Mavers à Rock en Seine. (…) on aurait
 finalement préféré que le cintré Mavers et son bassiste (…) ratent leur avion ou
 que celui-ci se crashe sur le siège du FN. Alors le public est circonspect (et
 on est poli). «Ils sont totalement défoncés ou quoi?» «Ils font la balance,

--- a/2011/2011-09-29-la-presse-des-deschiens.md
+++ b/2011/2011-09-29-la-presse-des-deschiens.md
@@ -9,6 +9,6 @@ date: 2011-09-29 19:26:43 +0200
 ---
 
 Francis Morel prendrait la tête des
-[_Echos_](http://www.lemonde.fr/actualite-medias/article/2011/09/29/francis-morel-devrait-remplacer-nicolas-beytout-a-la-tete-des-echos_1580130_3236.html#ens_id=1244166)
-? Et pourquoi pas l'un de ses anciens compagnons, Bernard Lochet ou Patrick
+[_Echos_](http://www.lemonde.fr/actualite-medias/article/2011/09/29/francis-morel-devrait-remplacer-nicolas-beytout-a-la-tete-des-echos_1580130_3236.html#ens_id=1244166) ?
+Et pourquoi pas l'un de ses anciens compagnons, Bernard Lochet ou Patrick
 Duquesne, directeur de *La Tribune* ? Non, mais sérieusement… Le monde va mal !

--- a/2011/2011-10-25-dum-dum-girls-only-in-dreams.md
+++ b/2011/2011-10-25-dum-dum-girls-only-in-dreams.md
@@ -30,9 +30,10 @@ Chain. L'album n'avait donc pas déçu.
 {% asset dum-dum-girls-route-du-rock.jpg %}
 
 La tournée française, elle, avait déçu. Conforme à ce qu'en disait la presse, la
-prestation à la Route du Rock 2010 fut loin des sommets historiques du festival
-: la pose bas-résille-et-Ray-Ban des quatre filles du groupe n'est certes pas
-désagréable, mais derrière, pas grand chose. Les Inrocks avaient écrit
+prestation à la Route du Rock 2010 fut loin des sommets historiques du
+festival : la pose bas-résille-et-Ray-Ban des quatre filles du groupe n'est
+certes pas désagréable, mais derrière, pas grand chose. Les Inrocks avaient
+écrit
 [ici](http://www.lesinrocks.com/musique/musique-article/t/49359/date/2010-08-16/article/on-y-est-la-route-du-rock-jour-3/)
 la déception («les petits rollercoasters malins de l’album sont ici enchaînés
 sans grande vie, semblent presque interchangeables, les morceaux semblent cloués

--- a/2011/2011-11-05-flo-prend-l-eau.md
+++ b/2011/2011-11-05-flo-prend-l-eau.md
@@ -10,5 +10,5 @@ date: 2011-11-05 14:26:31 +0100
 
 Florence Arthaud a bien failli se noyer la semaine dernière, retrouvée dans la
 mer en état d'hypothermie. Et aucun média n'a dénié rediffuser
-[ce magnifique duo](http://www.youtube.com/watch?v=QJBBkrpMAW0). Le monde va mal
-!
+[ce magnifique duo](http://www.youtube.com/watch?v=QJBBkrpMAW0). Le monde va
+mal !

--- a/2012/2012-02-05-les-disques-de-decembre-2011.md
+++ b/2012/2012-02-05-les-disques-de-decembre-2011.md
@@ -26,10 +26,11 @@ brouillons. C'est chose faite pour décembre.
 
 ### The Black Keys - _El Camino_
 
-Malgré deux ou trois titres un rien faiblard (surtout en seconde partie d'album
-: _Sister_ ou _Nova Baby_ entre autres), les Black Keys restent malgré tout le
-groupe le plus cool des dernières années. _Lonely Boy_ (et [le clip qui va
-avec][i938]) ou _Little Black Submarines_ en témoignent de façon convaincante.
+Malgré deux ou trois titres un rien faiblard (surtout en seconde partie
+d'album : _Sister_ ou _Nova Baby_ entre autres), les Black Keys restent malgré
+tout le groupe le plus cool des dernières années. _Lonely Boy_ (et [le clip qui
+va avec][i938]) ou _Little Black Submarines_ en témoignent de façon
+convaincante.
 
 ### Atlas Sound - _Parallax_
 

--- a/2012/2012-02-08-lino-l-est-homme.md
+++ b/2012/2012-02-08-lino-l-est-homme.md
@@ -17,5 +17,5 @@ comments:
 Voilà
 [une information L'équipe](http://www.lequipe.fr/Tennis/Actualites/Li-na-jette-l-eponge/261774)
 qui va en décevoir beaucoup ! Cela veut dire que plus jamais nous ne pourrons
-[voir ça](http://www.ina.fr/economie-et-societe/vie-sociale/video/CAA81020718/debat-valery-giscard-d-estaing-francois-mitterrand.fr.html)
-? Le monde va mal !
+[voir ça](http://www.ina.fr/economie-et-societe/vie-sociale/video/CAA81020718/debat-valery-giscard-d-estaing-francois-mitterrand.fr.html) ?
+Le monde va mal !

--- a/2012/2012-02-16-sans-mon-duvet-quel-duvet.md
+++ b/2012/2012-02-16-sans-mon-duvet-quel-duvet.md
@@ -14,6 +14,5 @@ tags:
 ---
 
 Non, mais c'est quoi cette photo
-[Christophe Lemaître](http://www.lequipe.fr/Athletisme/Actualites/Premiere-sortie-pour-lemaitre/263266)
-?! Tu relaisses pousser ton duvet de suite ! Ah, je vous jure ! Le monde va mal
-!
+[Christophe Lemaître](http://www.lequipe.fr/Athletisme/Actualites/Premiere-sortie-pour-lemaitre/263266) ?!
+Tu relaisses pousser ton duvet de suite ! Ah, je vous jure ! Le monde va mal !

--- a/2012/2012-03-01-on-n-est-pas-des-blaireaux.md
+++ b/2012/2012-03-01-on-n-est-pas-des-blaireaux.md
@@ -9,5 +9,5 @@ date: 2012-03-01 18:49:47 +0100
 ---
 
 Parce que y en a marre de raser gratis, les américains
-[ont leurs moustaches qui frétillent](http://bigbrowser.blog.lemonde.fr/2012/03/01/rases-de-frais-les-moustachus-americains-exigent-des-reductions-dimpot/#xtor=RSS-32280322)
-! Chez nous, José Bové est aux abonnés absents… Le monde va mal !
+[ont leurs moustaches qui frétillent](http://bigbrowser.blog.lemonde.fr/2012/03/01/rases-de-frais-les-moustachus-americains-exigent-des-reductions-dimpot/#xtor=RSS-32280322) !
+Chez nous, José Bové est aux abonnés absents… Le monde va mal !

--- a/2012/2012-04-01-foot-et-litterature-2.md
+++ b/2012/2012-04-01-foot-et-litterature-2.md
@@ -9,8 +9,9 @@ date: 2012-04-01 23:08:00 +0200
 ---
 
 [Lors d'un précédent article][i877], on s'interrogeait sur la carrière
-footballistique de Victor Hugo. Eh bien, soyons rassurés, [il joue à Rennes][1]
-! Par contre, qu'a-t-il fait de son emblématique barbe ? Le monde va mal !
+footballistique de Victor Hugo. Eh bien, soyons rassurés, [il joue à
+Rennes][1] ! Par contre, qu'a-t-il fait de son emblématique barbe ? Le monde va
+mal !
 
 [1]: https://www.lequipe.fr/Football/FootballFicheJoueur20726.html
 

--- a/2012/2012-04-18-une-carte-mystere.md
+++ b/2012/2012-04-18-une-carte-mystere.md
@@ -13,5 +13,5 @@ actuellement à la Cité de la Musique, on apprend que le musicien est natif de
 Duluth, Minnesota. Mais ce que l'on ne nous dit pas, c'est que l'album
 [Highway 61 Revisited](http://fr.wikipedia.org/wiki/Highway_61_Revisited) lui
 coûta
-[pas moins de 3 wagons verts, 2 wagons blancs, 3 wagons rouges et 2 cartes loco](http://www.asmodee.com/ressources/articles/les-aventuriers-du-rail-les-techniques-des-champions.php)
-! Le monde va mal !
+[pas moins de 3 wagons verts, 2 wagons blancs, 3 wagons rouges et 2 cartes loco](http://www.asmodee.com/ressources/articles/les-aventuriers-du-rail-les-techniques-des-champions.php) !
+Le monde va mal !

--- a/2012/2012-06-09-les-pionniers-oublies-du-rock-francais.md
+++ b/2012/2012-06-09-les-pionniers-oublies-du-rock-francais.md
@@ -7,6 +7,7 @@ description:
   campagnes de France, avant de se transformer en tornade transgénérationnelle
   de l'autre côté de l'Atlantique. L’Encyclopédie Approximative du Rock and Roll
   rend hommage à trois de ces héros tricolores méconnus.
+category: Encyclopédie approximative du Rock and Roll
 authors:
   - Joe Gantdelaine
 wordpress_id: 1048
@@ -49,5 +50,5 @@ Mais, en pleine vague yéyé, le titre est un bide.
 
 Il y aurait encore tant et tant de compatriotes méconnus à citer ! Quid du Gros
 Dominique (appelé Domino par ses potes) ? Quid de Pote Houx (sans doute le nom
-de scène le plus mal choisi) ? La liste est bien trop longue pour l'Encyclopédie
-!
+de scène le plus mal choisi) ? La liste est bien trop longue pour
+l'Encyclopédie !

--- a/2012/2012-07-05-oklahoma-mise-sur-thabeet.md
+++ b/2012/2012-07-05-oklahoma-mise-sur-thabeet.md
@@ -9,5 +9,5 @@ date: 2012-07-05 12:00:08 +0200
 ---
 
 Ils misent sur
-[ma quoi](http://www.lequipe.fr/Basket/Actualites/Oklahoma-mise-sur-thabeet/296361)
-? Le monde va mal !
+[ma quoi](http://www.lequipe.fr/Basket/Actualites/Oklahoma-mise-sur-thabeet/296361) ?
+Le monde va mal !

--- a/2012/2012-09-25-tabernac.md
+++ b/2012/2012-09-25-tabernac.md
@@ -8,6 +8,6 @@ cover: celine-dion.jpg
 date: 2012-09-25 23:34:48 +0200
 ---
 
-[Arcade Fire va jouer avec Céline Dion](http://pitchfork.com/news/47983-arcade-fire-team-with-celine-dion-for-benefit-show/)
-? Bon, soit… Mais donc, faut s'attendre à quoi ensuite ? Radiohead featuring
+[Arcade Fire va jouer avec Céline Dion](http://pitchfork.com/news/47983-arcade-fire-team-with-celine-dion-for-benefit-show/) ?
+Bon, soit… Mais donc, faut s'attendre à quoi ensuite ? Radiohead featuring
 Garou ? Blur en duo avec Natasha St-Pier ? Le monde va mal !

--- a/2013/2013-03-22-deep-six-stay-right-here.md
+++ b/2013/2013-03-22-deep-six-stay-right-here.md
@@ -15,7 +15,7 @@ envoie du pâté.
 
 La seule page d'informations trouvée sur les autoroutes de l'information est sur
 le bien nommé
-[Wilfully Obscure](http://wilfullyobscure.blogspot.fr/2012/07/deep-6-garage-dor-1986-coyote.html)
-: bonne lecture les amis.
+[Wilfully Obscure](http://wilfullyobscure.blogspot.fr/2012/07/deep-6-garage-dor-1986-coyote.html) :
+bonne lecture les amis.
 
 (via [Matthew Caws](https://twitter.com/nadasurf/status/313747863836426240))

--- a/2015/2015-01-21-playlist-top-musique-2014.md
+++ b/2015/2015-01-21-playlist-top-musique-2014.md
@@ -63,8 +63,8 @@ Pour la playlist, j'ai choisi les deux titres les plus immédiats de l'album _In
 The Aeroplane Over The Sea_ mais son écoute intégrale, comme celle de son
 prédécesseur, _On Avery Island_, sont vivement recommandées.
 
-Et puis de la scie musicale quoi ! [Bravo Maestro
-!][bravo-maestro-classe-americaine]
+Et puis de la scie musicale quoi ! [Bravo
+Maestro !][bravo-maestro-classe-americaine]
 
 ### Gandi Lake
 

--- a/2015/2015-05-09-laurent-chalumeau.md
+++ b/2015/2015-05-09-laurent-chalumeau.md
@@ -24,8 +24,8 @@ le doute… Faut-il sauver Michel Sardou ?
 
 Ça commence par le conseil d'un copain qui me recommande _La Famille Bélier_,
 l'histoire d'une famille où les parents sont sourd-muets et la fille chanteuse.
-Ouais, OK, y'a François Damiens, Karin Viard et Eric Elmosnino qui jouent dedans
-? Allez ! Pourquoi pas.
+Ouais, OK, y'a François Damiens, Karin Viard et Eric Elmosnino qui jouent
+dedans ? Allez ! Pourquoi pas.
 
 {% asset famille_belier.jpg alt='Avec le recul, je me dis que chanter, ça doit marcher mieux que la guitare' %}
 

--- a/2016/2016-04-27-bruce-springsteen.md
+++ b/2016/2016-04-27-bruce-springsteen.md
@@ -8,9 +8,9 @@ cover: bruce.jpg
 cover_alt: Brousse lit
 description: >
   Il aura fallu du temps pour ce nouvel article de l'Encyclopédie Approximative
-  du Rock and Roll. La faute à l'illustration : un lion dans son milieu naturel
-  ? Trop facile ! Un gros plan d'un fromage frais de Provence ? Bof ! Après des
-  mois de labeur,  la voila, la seule, l'unique photo où Bruce lit.
+  du Rock and Roll. La faute à l'illustration : un lion dans son milieu
+  naturel ? Trop facile ! Un gros plan d'un fromage frais de Provence ? Bof !
+  Après des mois de labeur,  la voila, la seule, l'unique photo où Bruce lit.
 ---
 
 Surnommé le Boss, parce qu'il l'est et parce que c'est plus simple à prononcer,
@@ -25,10 +25,10 @@ Et on le répètera jamais assez, mais Brousse est multi-talent. Quand il ne jou
 pas avec le E-Backstreet Boys Band, il débouche les éviers mieux que les
 plombiers, il répare les joints de culasse mieux que n'importe quel garagiste.
 Dans la musique, il est l'inventeur des chansons avec "Born" dedans. Patrick
-Hernandez, John Fogerty et autre Loup des steppes, vous n'êtes que des suiveurs
-! Brousse est né pour courir en Amérique lui ! Et puis, il a aussi bourlingué au
-cinéma. Moi, j'ai jamais vu Tom Hanks se faire licencier parce qu'il avait chopé
-un bon gros virus dégueu. Par contre, les rues de Philadelphie, on les connait
-tous par cœur grâce à Brousse.
+Hernandez, John Fogerty et autre Loup des steppes, vous n'êtes que des
+suiveurs ! Brousse est né pour courir en Amérique lui ! Et puis, il a aussi
+bourlingué au cinéma. Moi, j'ai jamais vu Tom Hanks se faire licencier parce
+qu'il avait chopé un bon gros virus dégueu. Par contre, les rues de
+Philadelphie, on les connait tous par cœur grâce à Brousse.
 
 Bref, Brousse est tout puissant et c'est pas Gym Carré qui dira le contraire.


### PR DESCRIPTION
Fixing #70 created a weird side-effect that made the site look like this: 

<img width="738" alt="Screen Shot 2020-12-01 at 07 50 14" src="https://user-images.githubusercontent.com/456506/100706826-ee927f80-33a9-11eb-97fa-f0a35955e511.png">

This PR fixes that and also complements the fix to #70 by adding unbreakable spaces to occurrences where !, ? or : was at the beginning of the line (as opposed to in the middle of the line as fixed by a search and replace in a previous PR).