### PR TITLE
Adding missing data from articles

### DIFF
--- a/2005/2005-03-31-compile-hiver-2005.md
+++ b/2005/2005-03-31-compile-hiver-2005.md
@@ -3,6 +3,7 @@ layout: post
 title: Compile Hiver 2005
 authors:
   - Dirty Henry
+wordpress_id: 243
 category: Compile
 tags:
   - Arcade Fire

--- a/2005/2005-04-19-dirty-s-top-songs-ever.md
+++ b/2005/2005-04-19-dirty-s-top-songs-ever.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Dirty’s top songs ever
+wordpress_id: 232
 authors:
   - Dirty Henry
 tags:

--- a/2005/2005-04-26-peau-de-cochon.md
+++ b/2005/2005-04-26-peau-de-cochon.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Peau de cochon
+wordpress_id: 234
 authors:
   - Dirty Henry
 ---

--- a/2005/2005-05-21-arcade-fire-bloc-party.md
+++ b/2005/2005-05-21-arcade-fire-bloc-party.md
@@ -3,6 +3,7 @@ layout: post
 title: Les 2 meilleurs groupes de 2005 en 48 heures
 authors:
   - Dirty Henry
+wordpress_id: 239
 category: Concert
 tags:
   - Arcade Fire

--- a/2005/2005-05-23-oasis-rois-de-la-terre-battue.md
+++ b/2005/2005-05-23-oasis-rois-de-la-terre-battue.md
@@ -3,6 +3,7 @@ layout: post
 title: Oasis, rois de la terre battue
 authors:
   - Dirty Henry
+wordpress_id: 240
 category: Concert
 tags:
   - Oasis

--- a/2005/2005-06-05-vv-et-camille-lutte-serree.md
+++ b/2005/2005-06-05-vv-et-camille-lutte-serree.md
@@ -3,6 +3,7 @@ layout: post
 title: "VV et Camille : lutte serrée"
 authors:
   - Dirty Henry
+wordpress_id: 241
 tags:
   - concert
 ---

--- a/2005/2005-06-30-compile-printemps-2005.md
+++ b/2005/2005-06-30-compile-printemps-2005.md
@@ -3,6 +3,7 @@ layout: post
 title: Compile printemps 2005
 authors:
   - Dirty Henry
+wordpress_id: 244
 category: Compile
 tags:
   - Arcade Fire

--- a/2005/2005-09-30-compile-ete-2005.md
+++ b/2005/2005-09-30-compile-ete-2005.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Compile été 2005
+wordpress_id: 287
 authors:
   - Dirty Henry
 tags:

--- a/2005/2005-12-15-le-best-of-quot-c-est-lenoir-quot-2005.md
+++ b/2005/2005-12-15-le-best-of-quot-c-est-lenoir-quot-2005.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Le best-of "C'est Lenoir" 2005
+wordpress_id: 265
 authors:
   - Dirty Henry
 tags:

--- a/2005/2005-12-17-ami-des-stars.md
+++ b/2005/2005-12-17-ami-des-stars.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Ami des stars
+wordpress_id: 267
 ---
 
 {% asset valerie-leulliot.jpg %}

--- a/2005/2005-12-31-compile-automne-2005.md
+++ b/2005/2005-12-31-compile-automne-2005.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Compile automne 2005
+wordpress_id: 288
 authors:
   - Dirty Henry
 cover: automne-2005.jpg

--- a/2006/2006-01-16-first-impressions-of-the-earth.md
+++ b/2006/2006-01-16-first-impressions-of-the-earth.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: The Strokes - First Impressions of the Earth
+wordpress_id: 275
 authors:
   - Dirty Henry
 tags:

--- a/2006/2006-03-07-that-70s-football-show.md
+++ b/2006/2006-03-07-that-70s-football-show.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: That '70s Football Show
+wordpress_id: 284
 authors:
   - Dirty Henry
 cover: vintage-soccer-haircuts.jpg

--- a/2007/2007-07-04-neil-hannon-eurovision.md
+++ b/2007/2007-07-04-neil-hannon-eurovision.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Neil Hannon nous explique comment gagner l'Eurovision
+wordpress_id: 391
 authors:
   - Joe Gantdelaine
 ---

--- a/2010/2010-05-12-tsool-nan-toi-tu-soules.md
+++ b/2010/2010-05-12-tsool-nan-toi-tu-soules.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: TSOOL ⁈ Nan, toi, tu soûles !
+wordpress_id: 614
 description: >
   De la Suède, on retient toujours _Waterloo_ et l'Eurovision de 1974, Ikea,
   Ericsson et Lego bien qu'on se gourre royalement concernant ce dernier

--- a/2011/2011-10-06-podcast-01-en.md
+++ b/2011/2011-10-06-podcast-01-en.md
@@ -1,0 +1,70 @@
+---
+lang: en
+layout: post
+title: "Podcast #01"
+description:
+  'Say bye to the "Compiles MP3 du Net", and welcome the Dead Rooster Podcast !
+  For this first episode : Dum Dum Girls, You Won''t, Other Lives, Ben Lee, Pure
+  Bathing Culture, Pendentif, Jono McCleery and Reading Rainbow !'
+authors:
+  - Dirty Henry
+wordpress_id: 926
+cover: dead-rooster-podcast.jpg
+date: 2011-10-06 03:14:53 +0200
+categories:
+  - Artistes
+tags:
+  - Bleeding Rainbow
+  - Dum Dum Girls
+playlist:
+  - artist: Dum Dum Girls
+    title: Bedroom Eyes
+    asset: dum-dum-girls-on-in-dreams-thumbnail.jpg
+  - artist: You Won't
+    title: Television
+    asset: you-wont-television.jpg
+  - artist: Other Lives
+    title: For 12
+    asset: other-lives-tamer-animals.jpg
+  - artist: Ben Lee
+    title: Get Used To It
+    asset: ben-lee-get-used-to-it.jpg
+  - artist: Pure Bathing Culture
+    title: Ivory Coast
+    asset: pure-bathing-culture-culture-flat.jpg
+  - artist: Pendentif
+    title: Pendentif
+    asset: pendentif.jpg
+  - artist: Jono McCleery
+    title: Garden
+    asset: jono-mccleery-garden.jpg
+  - artist: Reading Rainbow
+    title: Dead End
+    asset: reading-rainbow-dead-end.jpg
+  - artist: Dum Dum Girls
+    title: Coming Down
+    asset: dum-dum-girls-on-in-dreams-thumbnail.jpg
+---
+
+[It's been a while since we stopped our "Compile MP3 du Net"][i725]. Why?
+Because the format wasn't practical, because Dead Rooster's server is too small
+to host audio files on a daily basis, because everything.
+
+So, we're gonna experiment with something new: a podcast!
+
+We're not going to commit to a schedule yet for this podcast. Let's just stay
+we'll try to put one online at least once every two months. The podcasting
+philosophy is and will be : no talking, just 9 unedited songs. That's the way we
+like it.
+
+With this post, we'd like to thank all the people we got in touch with to build
+this first episode. If all the artists we contact in the future are as nice as
+those, it will be pretty easy to keep a decent frequency. So thanks again to all
+of you music involved people! (let's just not use the word "industry" when
+talking about music)
+
+We hope you'll enjoy the show.
+
+(edit: the podcast has been discontinued)
+
+[i725]: {% post_url 2010/2010-12-06-compile-mp3-du-net-08 %}

--- a/2011/2011-10-06-podcast-01.md
+++ b/2011/2011-10-06-podcast-01.md
@@ -1,14 +1,14 @@
 ---
-lang: en
+lang: fr
 layout: post
 title: "Podcast #01"
-description:
-  'Say bye to the "Compiles MP3 du Net", and welcome the Dead Rooster Podcast !
-  For this first episode : Dum Dum Girls, You Won''t, Other Lives, Ben Lee, Pure
-  Bathing Culture, Pendentif, Jono McCleery and Reading Rainbow !'
+description: >-
+  Adieu les Compiles MP3 du Net, bonjour le Dead Rooster Podcast ! Avec pour ce
+  premier épisode : Dum Dum Girls, You Won't, Other Lives, Ben Lee, Pure Bathing
+  Culture, Pendentif, Jono McCleery et Reading Rainbow !
 authors:
   - Dirty Henry
-wordpress_id: 926
+wordpress_id: 924
 cover: dead-rooster-podcast.jpg
 date: 2011-10-06 03:14:53 +0200
 categories:
@@ -34,7 +34,7 @@ playlist:
     asset: pure-bathing-culture-culture-flat.jpg
   - artist: Pendentif
     title: Pendentif
-    asset: pendentif.jpg
+    asset: pendentif.jpgs
   - artist: Jono McCleery
     title: Garden
     asset: jono-mccleery-garden.jpg
@@ -46,25 +46,22 @@ playlist:
     asset: dum-dum-girls-on-in-dreams-thumbnail.jpg
 ---
 
-[It's been a while since we stopped our "Compile MP3 du Net"][i725]. Why?
-Because the format wasn't practical, because Dead Rooster's server is too small
-to host audio files on a daily basis, because everything.
+[Cela faisait 10 mois que nous n'avions plus fait de Compile MP3 du Net][i725].
+Pourquoi ? Parce que le format n'était pas pratique, parce que Dead Rooster est
+trop petit pour héberger lui-même des MP3. Parce que tout ça.
 
-So, we're gonna experiment with something new: a podcast!
+Alors on va expérimenter quelque chose de nouveau : le podcast !
 
-We're not going to commit to a schedule yet for this podcast. Let's just stay
-we'll try to put one online at least once every two months. The podcasting
-philosophy is and will be : no talking, just 9 unedited songs. That's the way we
-like it.
+Pas de promesse sur la fréquence du podcast, on va essayer de faire ça au moins
+tous les deux mois, au gré des envies et des accords des artistes car oui, tous
+les artistes ont donné leur accord pour ce premier épisode qui va droit au but :
+neuf titres, neuf pistes, pas de coupe sur les morceaux, pas de bla bla, que de
+la musique.
 
-With this post, we'd like to thank all the people we got in touch with to build
-this first episode. If all the artists we contact in the future are as nice as
-those, it will be pretty easy to keep a decent frequency. So thanks again to all
-of you music involved people! (let's just not use the word "industry" when
-talking about music)
+Alors merci à tous les artistes, les maisons de disques et leur entourage qui
+ont tous accepté la diffusion d'un de leur titre dans ce numéro que vous
+apprécierez, je l'espère.
 
-We hope you'll enjoy the show.
-
-(edit: the podcast has been discontinued)
+(edit: le podcast a été arrêté, trop long à mettre en place)
 
 [i725]: {% post_url 2010/2010-12-06-compile-mp3-du-net-08 %}

--- a/2013/2013-11-12-inside-llewyn-davis.md
+++ b/2013/2013-11-12-inside-llewyn-davis.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Inside Llewyn Davis
+wordpress_id: 1264
 description:
   Au cas où certains en doutaient encore, je crois qu'on peut affirmer que les
   frères Coen aiment le folk.

--- a/2013/2013-12-03-outside-llewyn-davis.md
+++ b/2013/2013-12-03-outside-llewyn-davis.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Outside Llewyn Davis
+wordpress_id: 1266
 description:
   Si on a désormais envie de jouer au bowling à chaque fois qu'on entend les
   Gipsy Kings, on dit merci qui ? Merci les frères Coen !

--- a/2014/2014-01-07-jordan-ayew-superman.md
+++ b/2014/2014-01-07-jordan-ayew-superman.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Jordan Ayew n'est donc pas Superman
+wordpress_id: 1267
 authors:
   - Dirty Henry
 category: Le monde va mal

--- a/2014/2014-01-21-the-notwist-kong.md
+++ b/2014/2014-01-21-the-notwist-kong.md
@@ -2,6 +2,7 @@
 layout: post
 title: The Notwist - Kong
 category: Chanson du jour
+wordpress_id: 1268
 ---
 
 Le nouvel album arrive courant février ! Ce deuxième extrait est nettement plus

--- a/2014/2014-01-31-eels-agatha-chang.md
+++ b/2014/2014-01-31-eels-agatha-chang.md
@@ -2,6 +2,7 @@
 layout: post
 title: Eels - Agatha Chang
 category: Chanson du jour
+wordpress_id: 1269
 ---
 
 {% soundcloud 131830691 %}

--- a/2014/2014-02-12-yo-la-dumpo.md
+++ b/2014/2014-02-12-yo-la-dumpo.md
@@ -4,6 +4,7 @@ title: Yo La Dumpo
 description: Dump j'adore, Yo La Tengo aussi. Petit hommage à Ira et sa bande.
 authors:
   - Joe Gantdelaine
+wordpress_id: 1270
 ---
 
 {% asset yolatengo-2.jpg %}

--- a/2014/2014-03-03-eurovision-2014.md
+++ b/2014/2014-03-03-eurovision-2014.md
@@ -6,6 +6,7 @@ description:
 authors:
   - Dirty Henry
 category: Le monde va mal
+wordpress_id: 1271
 ---
 
 {% asset donkey.jpg %}

--- a/2014/2014-04-30-j-aim-ascis-2-2.md
+++ b/2014/2014-04-30-j-aim-ascis-2-2.md
@@ -5,6 +5,7 @@ description:
   Suite et fin de mes pérégrinations mentales à propos de Jayloumurph.
 authors:
   - Joe Gantdelaine
+wordpress_id: 1273
 ---
 
 {% asset dinosaur-jr-vache.jpg %}

--- a/2015/2015-01-21-playlist-top-musique-2014.md
+++ b/2015/2015-01-21-playlist-top-musique-2014.md
@@ -11,6 +11,7 @@ cover_alt: Le podium, celui des champions
 description: >
   Dead Rooster donne ses médailles à l'occasion d'un comeback complètement 2.0 !
 lead-paragraph: true
+wordpress_id: 1275
 ---
 
 C’est janvier, ça fait longtemps qu’on ne l’a pas fait mais ne serait-ce pas le


### PR DESCRIPTION
* Restore wordpress_id to facilitate scripts to check that the migration from SPIP is complete;
* Add missing post podcast-01 in French. 