### PR TITLE
Fix of articles mentioning Jonathan Coe

### DIFF
--- a/2009/2009-02-10-bertrand-burgalat-april-march.md
+++ b/2009/2009-02-10-bertrand-burgalat-april-march.md
@@ -3,37 +3,45 @@ layout: post
 title: Initials B. B. & A. M.
 authors:
   - Dirty Henry
+excerpt: >-
+  Compte-rendu du concert de la paire Bertrand Burgalat/April March au New
+  Morning. C'était court mais c'était bath.
 wordpress_id: 223
 date: "2009-02-10 14:42:29 +0100"
 category: Concert
 tags:
   - April March
   - Bertrand Burgalat
+  - Jonathan Coe
 cover: april-march-bertrand-burgalat.jpg
 ---
+
+## Présentation des équipes
 
 **April March** est l'artiste méconnue la plus omniprésente du moment. Cela dure
 depuis la sortie de [_Boulevard de la mort_][1], de Tarantino, en juin 2007. Le
 cinéaste a remis au goût du jour sa double reprise de France Gall en version
-originale (_Laisse tomber les filles_) et version américanisée (_Chick Habit_)
-qui depuis inonde les clubs indé, les bandes son de publicités et même certaines
-sonneries de portable. Ce titre a pourtant déjà 15 ans et date de l'époque à
-laquelle la californienne pour le moins francophile s'était laissée aller à
-reprendre de nombreux titres du répertoire français, pour la plupart signés
-Gainsbourg : _Laisse tomber les filles_ (donc), _Caribou_, _La Chanson de
-Prévert_, _Cet air-là_, etc…
+originale ([_Laisse tomber les filles_][3]) et version américanisée ([_Chick
+Habit_][4]) qui depuis inonde les clubs indé, les bandes son de publicités et
+même certaines sonneries de portable. Ce titre a pourtant déjà 15 ans et date de
+l'époque à laquelle la californienne pour le moins francophile s'était laissée
+aller à reprendre de nombreux titres du répertoire français, pour la plupart
+signés Gainsbourg : _Laisse tomber les filles_ (donc), [_Caribou_][5], [_La
+Chanson de Prévert_][6], [_Cet air-là_][7], etc…
 
 Rien d'anormal donc à ce qu'elle finisse par rencontrer **Bertrand Burgalat**,
-chef de tribu, via son label Tricatel ([nom inspiré de *l'Aile ou la
-Cuisse* ?][2]), de ce qui se fait de mieux en matière de revival de pop/yéyé
-élégante d'ascendance gainsbourienne. Il produit en effet Katerine, A.S Dragon,
-Héléna Noguerra ou Valérie Lemercier mais aussi d'autres opus ovnis, à la
-croisée des chemins du rock et de la littérature, comme ces disques de Michel
-Houellebecq ou de Jonathan Coe. Lui-même est d'ailleurs musicien et propose ces
-semaines-ci une tournée d'adieu (à prendre au sérieux ?) en compagnie de sa muse
-April March pour lequel il a écrit deux disques de très haut niveau
-(quoiqu'assez radicalement différent de son _Chick Habit_ ou de ses fulgurances
-garage fabriquées avec The Makers) : _Chrominance Decoder_ et _Triggers_.
+chef de tribu, via son label Tricatel[^1], de ce qui se fait de mieux en matière
+de revival de pop/yéyé élégante d'ascendance gainsbourienne. Il produit en effet
+Katerine, A.S Dragon, Héléna Noguerra ou Valérie Lemercier mais aussi d'autres
+opus ovnis, à la croisée des chemins du rock et de la littérature, comme ces
+disques de Michel Houellebecq ou de Jonathan Coe. Lui-même est d'ailleurs
+musicien et propose ces semaines-ci une tournée d'adieu (à prendre au sérieux ?)
+en compagnie de sa muse April March pour lequel il a écrit deux disques de très
+haut niveau (quoiqu'assez radicalement différent de son _Chick Habit_ ou de ses
+fulgurances garage fabriquées avec The Makers) : [_Chrominance Decoder_][9] et
+[_Triggers_][10].
+
+## Le concert
 
 Pas de première partie ce mercredi 28 janvier, à l'Elysée Montmartre. Quelques
 figures notables ont pris place autour de la scène (Michka Assayas et Héléna
@@ -45,10 +53,10 @@ voix nonchalante sur des compositions en français ou en anglais, lors desquelle
 il n'hésite pas à faire profiter l'assistance de son accent pour le moins
 approximatif. L'ensemble devient la B.O. idéale de vacances en bord de mer,
 plein de copains en bras de chemise debout sur la banquette arrière, accoudés au
-toit de la 2CV, toit ouvrant béant, brin de blé au bord des lèvres et chapeau de
-paille sur la tête. Sur scène, Burgalat (et son groupe) est un peu à la pop 60's
-ce que Katerine (et les Little Rabbits) est au punk 70's : une figure décadente
-et féminine d'élégance du genre.
+toit de la 2CV, toit ouvrant béant, brin de blé ou cibiche au bord des lèvres et
+chapeau de paille sur la tête. Sur scène, Burgalat (et son groupe) est un peu à
+la pop 60's ce que Katerine (et les Little Rabbits) est au punk 70's : une
+figure décadente et androgyne d'élégance du genre.
 
 Après presque une heure de concert, April March rentre en scène et prend le
 micro. Bertrand Burgalat reprend alors un simple costume de musicien pour
@@ -60,7 +68,18 @@ aimé que ça dure plus longtemps. Burgalat le sent bien et rappelle ses sbires
 pour un rappel généreux mais évitable : ils vont rejouer un titre du concert.
 Pour la prochaine tournée d'adieu, il faudra bosser plus de morceaux les mecs !
 
-Photo : [©*Le seb*](http://flickr.com/photos/seblascaux/)
+Photo : [©*Le seb*](https://flickr.com/photos/seblascaux/)
 
-[1]: http://www.allocine.fr/film/fichefilm_gen_cfilm=108247.html
-[2]: http://fr.wikipedia.org/wiki/Tricatel
+[^1]:
+    Nom inspiré par la machine industrielle à malbouffe de [_L'Aile ou la
+    Cuisse_][8].
+
+[1]: https://www.themoviedb.org/movie/1991-death-proof
+[3]: https://song.link/us/i/323848675
+[4]: https://song.link/fr/i/220150488
+[5]: https://song.link/us/i/497838331
+[6]: https://song.link/us/i/323848683
+[7]: https://song.link/us/i/497838335
+[8]: https://www.themoviedb.org/movie/761-l-aile-ou-la-cuisse
+[9]: https://album.link/fr/i/417082825
+[10]: https://album.link/fr/i/408952972

--- a/2011/2011-03-03-la-vie-tres-privee-de-mr-sim-de-jonathan-coe.md
+++ b/2011/2011-03-03-la-vie-tres-privee-de-mr-sim-de-jonathan-coe.md
@@ -1,19 +1,15 @@
 ---
 layout: post
 title: La vie très privée de Mr Sim de Jonathan Coe
-description:
-  "[Marcello Proust](auteur5) m'a dit que Dead Rooster ne parlait pas assez de
-  bouquins. Dont acte !"
-authors:
-  - Dirty Henry
+excerpt: >-
+  Marcello Proust m’a dit que Dead Rooster ne parlait pas assez de bouquins.
+  Dont acte !
+author: Dirty Henry
 wordpress_id: 793
 cover: jonathan-coe-mr-sim.jpg
 date: 2011-03-03 19:40:45 +0100
-categories:
-  - Catégories
-  - Artistes
+category: Le bouquin
 tags:
-  - Livre
   - Jonathan Coe
 ---
 
@@ -35,32 +31,34 @@ fille viennent de quitter la maison, et visiblement, ce bon vieux Max commence �
 se dire qu'il est temps de faire le point sur ce qui a bien pu déconner en cours
 de route.
 
+## Présentation des joueurs
+
 Avant de continuer, parlons un petit peu de l'auteur. **Jonathan Coe** est un
 auteur britannique de 50 ans, originaire de Birmingham, surtout connu pour trois
 ouvrages :
 
-- [_Testament à l'anglaise_](http://fr.wikipedia.org/wiki/Testament_%C3%A0_l'anglaise)
-  (_What A Carve Up!_ en V.O.), satire policière pleine d'humour noir sur la
-  société anglaise des années 80 marquée par cette bonne vieille Maggie Thatcher
-  (à ne pas confondre avec
-  [Maguy tout court, qui voit souvent rouge](http://www.dailymotion.com/video/x383g_maguy_music)),
-- le diptyque _Bienvenue au Club/Le Cercle Fermé_ (_The Rotters' Club/The Closed
-  Circle_), au sommet de mon panthéon personnel et que je recommande tout
-  particulièrement, qui traite de la petite histoire d'un groupe d'adolescents
-  dans le grande histoire britannique des années 70 (avec l'IRA, les grandes
-  grèves nationales et le prog rock), puis de leur âge adulte lors des années 90
-  (avec Tony Blair notamment)
+- [_Testament à l'anglaise_][1] (_What A Carve Up!_ en V.O.), satire policière
+  pleine d'humour noir sur la société anglaise des années 80 marquée par cette
+  bonne vieille Maggie Thatcher[^1] ;
+- le diptyque [_Bienvenue au Club_][3]/[_Le Cercle Fermé_][4] (_The Rotters'
+  Club_/_The Closed Circle_), au sommet de mon panthéon personnel et que je
+  recommande tout particulièrement, qui traite de la petite histoire d'un groupe
+  d'adolescents dans le grande histoire britannique des années 70 (avec l'IRA,
+  les grandes grèves nationales et le prog rock), puis de leur âge adulte lors
+  des années 90 (avec Tony Blair notamment)
 
 Jonathan Coe était jusqu'à présent un auteur qui parle (au sens fort du terme)
 tout en restant très drôle et assez lucide sur le monde qui l'entoure. Depuis
 son dernier ouvrage, Coe a dû découvrir Facebook, le GPS et a probablement relu
-Houellebecq, son partenaire de label (cf. [cet article][i223]) pour apporter une
-touche de glauque à son portrait de Sim («comme le comique» dit l'ouvrage : je
-suis donc curieux de savoir ce que dit la V.O. à ce sujet, feu Simon Berryer
-serait-il une vedette internationale ?). Mais encore une fois, et malgré une fin
-que j'ai trouvé légèrement faiblarde, son livre est une réussite et Coe reste le
-seul auteur dont j'ai lu la quasi-totalité des livres sans avoir jamais été déçu
+Houellebecq, [son partenaire de label][i223], pour apporter une touche de
+glauque à son portrait de Sim (« comme le comique » dit l'ouvrage : je suis donc
+curieux de savoir ce que dit la V.O. à ce sujet, feu Simon Berryer serait-il une
+vedette internationale ?). Mais encore une fois, et malgré une fin que j'ai
+trouvé légèrement faiblarde, son livre est une réussite et Coe reste le seul
+auteur dont j'ai lu la quasi-totalité des livres sans avoir jamais été déçu
 (c'est à toi que je m'adresse Nick Hornby !).
+
+## Petit détour vers Donald Crowhurst
 
 Un intérêt tout particulier de ce livre réside dans la découverte du personnage
 de **Donald Crowhurst**. Le Golden Globe Challenge fut un défi de voile adressé
@@ -79,14 +77,21 @@ des recherches permanentes pour trouver la racine carrée de -1, et s'était
 probablement suicidé. Deux items sont indiqués dans le livre et traite de cette
 histoire :
 
-- le livre _L'étrange voyage de Donald Crowhurst_, de Nicholas Tomalin et Ron
-  Hall
-- le documentaire _Deep Water_, de Louise Osmond et Jerry Rothwell
+- le livre [_L'étrange voyage de Donald Crowhurst_][5], de Nicholas Tomalin et
+  Ron Hall
+- le documentaire [_Deep Water_][6], de Louise Osmond et Jerry Rothwell
 
 Les voilà désormais ajoutés à ma liste de trucs à lire et à voir (qui
-bizarrement, ne fait que grandir). Je vous quitte avec la bande annonce de *Deep
-Water* :
-
-{% youtube ePAfjxI4rws %}
+bizarrement, ne fait que grandir).
 
 [i223]: {% post_url 2009/2009-02-10-bertrand-burgalat-april-march %}
+
+[^1]: À ne pas confondre avec [Maguy tout court, qui voit souvent rouge][2]
+
+[1]: https://www.babelio.com/livres/Coe-Testament-a-langlaise/5854
+[2]: https://youtu.be/qvc_7lBpVL0
+[3]: https://www.babelio.com/livres/Coe-Bienvenue-au-club/5850
+[4]: https://www.babelio.com/livres/Coe-Le-Cercle-ferme/5718
+[5]:
+  https://www.babelio.com/livres/Tomalin-Letrange-voyage-de-Donald-Crowhurst/1022113
+[6]: https://www.themoviedb.org/movie/15030-deep-water


### PR DESCRIPTION
* https://deadrooster.org/la-vie-tres-privee-de-mr-sim-de-jonathan-coe/
* https://deadrooster.org/bertrand-burgalat-april-march/

Hopefully that will bring them back on Google's index.